### PR TITLE
feat: upgrade to nwp500-python v1.2.2 and fix fan PWM units

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,9 @@ The integration maps nwp500-python library modes to Home Assistant water heater 
 | HIGH_DEMAND (4) | high_demand | High performance hybrid mode |
 | ELECTRIC (2) | electric | Electric elements only |
 
-## Library Version 1.2.0 Features
+## Library Version 1.2.2 Features
 
-This integration uses nwp500-python v1.2.0 which includes:
+This integration uses nwp500-python v1.2.2 which includes:
 
 ### Enhanced MQTT Reconnection and Reliability
 - **Improved MQTT Reconnection**: Fixes connection interruption issues with AWS MQTT (AWS_ERROR_MQTT_UNEXPECTED_HANGUP)
@@ -175,7 +175,7 @@ Most sensors are **disabled by default** to avoid cluttering your entity list. Y
 ### Common Issues
 
 **Integration won't load:**
-- Ensure nwp500-python==1.2.0 is installed
+- Ensure nwp500-python==1.2.2 is installed
 - Check Home Assistant logs for specific errors
 
 **No device status updates:**

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -63,7 +63,7 @@ async def validate_input(hass, data: dict[str, Any]) -> dict[str, Any]:
     if not NWP500_AVAILABLE:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            "pip install nwp500-python==1.2.0 awsiotsdk>=1.20.0"
+            "pip install nwp500-python==1.2.2 awsiotsdk>=1.20.0"
         )
         raise CannotConnect("nwp500-python library not available")
     

--- a/custom_components/nwp500/const.py
+++ b/custom_components/nwp500/const.py
@@ -218,7 +218,7 @@ DEVICE_STATUS_SENSORS: Final = {
     "fan_pwm": {
         "name": "Fan PWM",
         "device_class": None,
-        "unit": "%",
+        "unit": None,
         "state_class": "measurement",
         "entity_registry_enabled_default": False,
     },

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -106,7 +106,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install with: "
-                "pip install nwp500-python==1.2.0 awsiotsdk>=1.20.0"
+                "pip install nwp500-python==1.2.2 awsiotsdk>=1.20.0"
             )
             raise UpdateFailed(f"nwp500-python library not available: {err}") from err
         

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/eman/ha_nwp500",
   "integration_type": "device",
   "iot_class": "cloud_polling",
-  "requirements": ["nwp500-python==1.2.0", "awsiotsdk>=1.20.0"],
+  "requirements": ["nwp500-python==1.2.2", "awsiotsdk>=1.20.0"],
   "version": "1.0.0"
 }


### PR DESCRIPTION
- Update nwp500-python dependency from v1.2.0 to v1.2.2
- Fix fan PWM sensor unit from '%' to None (unitless)
- Update error messages and documentation to reference v1.2.2
- PWM values are raw digital values, not percentages

Changes:
- manifest.json: Updated requirement to nwp500-python==1.2.2
- coordinator.py: Updated installation error message
- config_flow.py: Updated installation error message
- const.py: Changed fan_pwm unit from '%' to None
- README.md: Updated documentation for v1.2.2