### PR TITLE
Update to nwp500-python v3.1.4 and fix reconnection event handler

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==3.1.3` - Core library for Navien device communication
+- `nwp500-python==3.1.4` - Core library for Navien device communication
 - `awsiotsdk>=1.25.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ This is a Home Assistant custom component that provides integration for Navien N
   - **GitHub Repository**: https://github.com/eman/nwp500-python
   - **Documentation**: https://nwp500-python.readthedocs.io/en/stable/
   - **PyPI Package**: https://pypi.org/project/nwp500-python/
-  - **Current Version**: 3.1.3 (see `custom_components/nwp500/manifest.json`)
+  - **Current Version**: 3.1.4 (see `custom_components/nwp500/manifest.json`)
   - **Note**: When instructions refer to "adopting a new library version" or "updating the library," they mean updating nwp500-python
 
 ### Home Assistant Integration

--- a/README.md
+++ b/README.md
@@ -107,9 +107,13 @@ The integration maps nwp500-python library modes to Home Assistant water heater 
 | HIGH_DEMAND (4) | high_demand | High performance hybrid mode |
 | ELECTRIC (2) | electric | Electric elements only |
 
-## Library Version 3.1.3
+## Library Version 3.1.4
 
-This integration uses nwp500-python v3.1.3 which includes:
+This integration uses nwp500-python v3.1.4 which includes:
+
+### Improvements in v3.1.4
+- **MQTT Reconnection**: Fixed MQTT reconnection failures due to expired AWS credentials
+- **Connection Recovery**: Improved automatic recovery from connection interruptions
 
 ### Improvements in v3.1.3
 - **MQTT Reliability**: Improved MQTT reconnection reliability with active reconnection

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -118,7 +118,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            "pip install nwp500-python==3.1.3 awsiotsdk>=1.25.0"
+            "pip install nwp500-python==3.1.4 awsiotsdk>=1.25.0"
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -273,7 +273,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                "pip install nwp500-python==3.1.3 awsiotsdk>=1.25.0"
+                "pip install nwp500-python==3.1.4 awsiotsdk>=1.25.0"
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"
@@ -462,13 +462,12 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
         """Handle MQTT connection restored event."""
         _LOGGER.info("MQTT connection restored: %s", event_data)
 
-    def _on_reconnection_failed(self, event_data: dict[str, Any]) -> None:
+    def _on_reconnection_failed(self, attempt_count: int) -> None:
         """Handle MQTT reconnection failed event.
 
         When reconnection fails after max attempts, automatically reset
         the reconnection state and trigger a new reconnection cycle.
         """
-        attempt_count = event_data.get("attempt_count", 0)
         _LOGGER.warning(
             "MQTT reconnection failed after %d attempts. "
             "Resetting reconnection state and retrying...",

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -8,6 +8,6 @@
   "issue_tracker": "https://github.com/eman/ha_nwp500/issues",
   "integration_type": "device",
   "iot_class": "cloud_polling",
-  "requirements": ["nwp500-python==3.1.3", "awsiotsdk>=1.25.0"],
+  "requirements": ["nwp500-python==3.1.4", "awsiotsdk>=1.25.0"],
   "version": "0.1.1"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # These dependencies are also listed in custom_components/nwp500/manifest.json
 
 # Core integration library
-nwp500-python==3.1.3
+nwp500-python==3.1.4
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.25.0


### PR DESCRIPTION
## Summary

This PR updates the integration to use **nwp500-python v3.1.4** and fixes a bug in the MQTT reconnection event handler.

## Changes

### Version Update (3.1.3 → 3.1.4)
- ✅ Updated `manifest.json` requirements
- ✅ Updated `requirements.txt`
- ✅ Updated error messages in `coordinator.py` and `config_flow.py`
- ✅ Updated documentation in `README.md`, `.devcontainer/README.md`, and `.github/copilot-instructions.md`

### Bug Fix
- ✅ Fixed `_on_reconnection_failed` event handler signature
  - Changed parameter from `dict[str, Any]` to `int`
  - Matches actual event emission from nwp500-python library
  - Resolves `AttributeError: 'int' object has no attribute 'get'`

## What's New in v3.1.4

From the [nwp500-python v3.1.4 release](https://github.com/eman/nwp500-python/releases/tag/v3.1.4):
- **MQTT Reconnection**: Fixed MQTT reconnection failures due to expired AWS credentials
- **Connection Recovery**: Improved automatic recovery from connection interruptions

## Testing

- ✅ Type checking: `tox -e mypy` passes with zero errors
- ✅ All version references updated correctly
- ✅ Event handler signature matches library implementation

## Related Issues

Fixes the error reported in logs:
```
ERROR [nwp500.events] Error in 'reconnection_failed' event handler: 'int' object has no attribute 'get'
```