### PR TITLE
fix: add MqttError exception handling to prevent silent coordinator failures

### DIFF
--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -293,7 +293,15 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
 
             return device_data
 
-        except (AwsCrtError, RuntimeError, OSError, TimeoutError, AttributeError, KeyError) as err:
+        except (
+            AwsCrtError,
+            RuntimeError,
+            OSError,
+            TimeoutError,
+            AttributeError,
+            KeyError,
+            MqttError,
+        ) as err:
             # Track failed update time as well
             duration = time.monotonic() - start_time
             _LOGGER.error(
@@ -506,7 +514,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
                 "Authentication failed. Please re-authenticate through "
                 "the notifications panel or Settings > Devices & Services."
             ) from err
-        except (AwsCrtError, RuntimeError, OSError, TimeoutError) as err:
+        except (AwsCrtError, RuntimeError, OSError, TimeoutError, MqttError) as err:
             _LOGGER.error("Failed to setup clients: %s", err)
             await self.async_shutdown()
             raise UpdateFailed(
@@ -737,7 +745,14 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
                 return True  # Command is queued, will be sent on reconnect
             _LOGGER.error("Failed to send command %s: %s", command, err)
             return False
-        except (RuntimeError, OSError, TimeoutError, ValueError, TypeError) as err:
+        except (
+            RuntimeError,
+            OSError,
+            TimeoutError,
+            ValueError,
+            TypeError,
+            MqttError,
+        ) as err:
             _LOGGER.error("Failed to send command %s: %s", command, err)
             return False
 
@@ -788,7 +803,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
                         device.device_info.mac_address,
                         err,
                     )
-            except (RuntimeError, OSError, TimeoutError) as err:
+            except (RuntimeError, OSError, TimeoutError, MqttError) as err:
                 _LOGGER.error(
                     "Failed to send manual device info request for %s: %s",
                     device.device_info.mac_address,


### PR DESCRIPTION
## Critical Bug Fix

### Problem
The v5.0.0 upgrade (commit d4ac934) introduced new  exception types but failed to add them to exception handlers throughout the coordinator. This caused **silent failures** when MQTT operations raised  or its subclasses (, ), causing the coordinator to stop updating without any error logs.

### Root Cause
When MQTT operations failed and raised , the exceptions were not caught by our handlers. Instead, they were silently caught by Home Assistant's base coordinator class, which stopped the integration from updating without logging the error.

### Solution
Added  to exception handlers in 4 critical methods:
1. **`_async_update_data()`** - Main coordinator update loop
2. **`_setup_clients()`** - Client initialization
3. **`async_control_device()`** - Device control commands
4. **`async_request_device_info()`** - Device info requests

### Design Decision
We catch the base `MqttError` class rather than specific exceptions (`MqttNotConnectedError`, `MqttConnectionError`) because:
- The library explicitly designed `MqttError` as a base class for consumers to catch all MQTT errors with a single handler (per library documentation)
- All MQTT errors are handled the same way in our code (log + raise UpdateFailed or return False)
- Future-proof: automatically catches any new MQTT exception types added to the library
- Cleaner, more maintainable code

### Impact
- ✅ Coordinator now properly catches and logs MQTT exceptions
- ✅ Prevents silent coordinator failures that stop all updates
- ✅ Users get proper error messages for debugging
- ✅ Integration continues attempting updates even when MQTT operations fail

### Testing
- ✅ mypy type checking: Success (0 errors)
- ✅ Exception hierarchy verified: `MqttError` catches all MQTT exception types
- ✅ No changes to application logic, only exception handling

### Files Changed
- `custom_components/nwp500/coordinator.py` (19 insertions, 4 deletions)

Closes #24