### PR TITLE
Update nwp500-python to 6.0.3

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==6.0.2` - Core library for Navien device communication
+- `nwp500-python==6.0.3` - Core library for Navien device communication
 - `awsiotsdk>=1.25.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,7 +11,7 @@ This is a Home Assistant custom component that provides integration for Navien N
   - **GitHub Repository**: https://github.com/eman/nwp500-python
   - **Documentation**: https://nwp500-python.readthedocs.io/en/stable/
   - **PyPI Package**: https://pypi.org/project/nwp500-python/
-  - **Current Version**: 6.0.2 (see `custom_components/nwp500/manifest.json`)
+  - **Current Version**: 6.0.3 (see `custom_components/nwp500/manifest.json`)
   - **Note**: When instructions refer to "adopting a new library version" or "updating the library," they mean updating nwp500-python
 
 ### Home Assistant Integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Updated nwp500-python dependency to 6.0.2
+- Updated nwp500-python dependency to 6.0.3
 
 ## Library Dependency: nwp500-python
 
 This section tracks changes in the nwp500-python library that this integration depends on.
+
+### v6.0.3 (2025-11-20)
+
+**BREAKING CHANGES**: Migration from custom dataclass-based models to Pydantic BaseModel implementations.
+
+#### Removed
+- Removed legacy dataclass implementations for models. All models now inherit from `NavienBaseModel` (Pydantic).
+- Removed manual `from_dict` constructors.
+- Removed field metadata conversion system.
+
+#### Changed
+- Models now use snake_case attribute names consistently; camelCase keys from API/MQTT are mapped automatically via Pydantic.
+
+**Full release notes**: https://github.com/eman/nwp500-python/releases/tag/v6.0.3
 
 ### v6.0.2 (2025-11-15)
 

--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ This error means authentication succeeded, but the Navien cloud API returned an 
    - Contact the device owner if you're using a shared device
 
 **Integration won't load:**
-- Ensure nwp500-python==6.0.2 is installed
+- Ensure nwp500-python==6.0.3 is installed
 - Check Home Assistant logs for specific errors
 
 **No device status updates:**

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -178,7 +178,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            "pip install nwp500-python==6.0.2 awsiotsdk>=1.25.0"
+            "pip install nwp500-python==6.0.3 awsiotsdk>=1.25.0"
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -523,7 +523,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                "pip install nwp500-python==6.0.2 awsiotsdk>=1.25.0"
+                "pip install nwp500-python==6.0.3 awsiotsdk>=1.25.0"
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # These dependencies are also listed in custom_components/nwp500/manifest.json
 
 # Core integration library
-nwp500-python==6.0.2
+nwp500-python==6.0.3
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.25.0

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest-homeassistant-custom-component>=0.13.0
     pytest-timeout>=2.1.0
     homeassistant>=2024.1.0
-    nwp500-python==6.0.2
+    nwp500-python==6.0.3
     awsiotsdk>=1.25.0
 skip_install = True
 commands =
@@ -30,7 +30,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2024.1.0
-    nwp500-python==6.0.2
+    nwp500-python==6.0.3
     awsiotsdk>=1.25.0
 skip_install = True
 commands =
@@ -41,7 +41,7 @@ description = Run pyright type checking
 deps =
     pyright>=1.1.0
     homeassistant>=2024.1.0
-    nwp500-python==6.0.2
+    nwp500-python==6.0.3
     awsiotsdk>=1.25.0
 skip_install = True
 commands =


### PR DESCRIPTION
Updates the `nwp500-python` library to version 6.0.3.

**Changelog:**
* **BREAKING CHANGES**: Migration from custom dataclass-based models to Pydantic BaseModel implementations.
* Removed legacy dataclass implementations for models.
* Models now use snake_case attribute names consistently.

Verified with `tox -e mypy`.