### PR TITLE
feat: Add reservation schedule management services

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==6.0.7` - Core library for Navien device communication
+- `nwp500-python==6.1.0` - Core library for Navien device communication
 - `awsiotsdk>=1.25.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ This is a Home Assistant custom component that provides integration for Navien N
   - **GitHub Repository**: https://github.com/eman/nwp500-python
   - **Documentation**: https://nwp500-python.readthedocs.io/en/stable/
   - **PyPI Package**: https://pypi.org/project/nwp500-python/
-  - **Current Version**: 6.0.7 (see `custom_components/nwp500/manifest.json`)
+  - **Current Version**: 6.1.0 (see `custom_components/nwp500/manifest.json`)
   - **Note**: When instructions refer to "adopting a new library version" or "updating the library," they mean updating nwp500-python
 
 ### Home Assistant Integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,12 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Reservation Scheduling**: New services for managing programmed temperature/mode schedules
+  - `nwp500.set_reservation`: Create a single reservation entry with user-friendly parameters
+  - `nwp500.update_reservations`: Replace all reservations with a new set (advanced)
+  - `nwp500.clear_reservations`: Remove all reservation schedules
+  - `nwp500.request_reservations`: Request current reservation data from device
+- Reservations allow automatic mode and temperature changes at scheduled times
+- Supports up to 7 reservation entries per device
+
 ### Changed
-- Updated nwp500-python dependency to 6.0.7
+- Updated nwp500-python dependency to 6.1.0
 
 ## Library Dependency: nwp500-python
 
 This section tracks changes in the nwp500-python library that this integration depends on.
+
+### v6.1.0 (2025-12-03)
+
+**BREAKING CHANGES**: Temperature API simplified with Fahrenheit input
+
+#### Changed
+- `build_reservation_entry()` now accepts `temperature_f` (Fahrenheit) instead of raw `param` value
+- `set_dhw_temperature()` now accepts Fahrenheit directly instead of raw integer
+- Temperature conversion to half-degrees Celsius handled automatically by the library
+
+#### Removed
+- `set_dhw_temperature_display()` removed (was using incorrect conversion formula)
+
+#### Added
+- `fahrenheit_to_half_celsius()` utility function for advanced use cases
+
+#### Fixed
+- Temperature encoding bug in `set_dhw_temperature()` - was using incorrect "subtract 20" formula
+
+**Full release notes**: https://github.com/eman/nwp500-python/releases/tag/v6.1.0
+
+### v6.0.8 (2025-12-02)
+
+#### Changed
+- Maintenance release, version bump for PyPI
+
+**Full release notes**: https://github.com/eman/nwp500-python/releases/tag/v6.0.8
 
 ### v6.0.7 (2025-11-30)
 

--- a/README.md
+++ b/README.md
@@ -112,9 +112,44 @@ The integration supports these DHW operation modes:
 - **Energy Saver**: Hybrid mode for balance
 - **High Demand**: Hybrid mode for fast heating
 
+### Reservation Scheduling
+
+The integration provides services for programming automatic mode and temperature changes:
+
+#### Services
+
+| Service | Description |
+|---------|-------------|
+| `nwp500.set_reservation` | Create a single reservation with user-friendly parameters |
+| `nwp500.update_reservations` | Replace all reservations (advanced) |
+| `nwp500.clear_reservations` | Remove all reservation schedules |
+| `nwp500.request_reservations` | Request current reservation data from device |
+
+#### Example: Set a Weekday Morning Reservation
+
+```yaml
+service: nwp500.set_reservation
+target:
+  device_id: your_device_id
+data:
+  enabled: true
+  days:
+    - Monday
+    - Tuesday
+    - Wednesday
+    - Thursday
+    - Friday
+  hour: 6
+  minute: 30
+  mode: high_demand
+  temperature: 140
+```
+
+This creates a reservation that activates High Demand mode at 6:30 AM on weekdays with a target temperature of 140°F.
+
 ## Library Version
 
-This integration currently uses **nwp500-python v6.0.7**.
+This integration currently uses **nwp500-python v6.1.0**.
 
 For version history and changelog, see [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python).
 
@@ -179,7 +214,7 @@ This error means authentication succeeded, but the Navien cloud API returned an 
    - Contact the device owner if you're using a shared device
 
 **Integration won't load:**
-- Ensure nwp500-python==6.0.7 is installed
+- Ensure nwp500-python==6.1.0 is installed
 - Check Home Assistant logs for specific errors
 
 **No device status updates:**

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -3,11 +3,15 @@
 from __future__ import annotations
 
 import logging
+from typing import Any
 
+import voluptuous as vol
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.const import ATTR_DEVICE_ID, Platform
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import DOMAIN
@@ -22,6 +26,64 @@ PLATFORMS: list[Platform] = [
     Platform.SWITCH,
     Platform.NUMBER,
 ]
+
+# Service names
+SERVICE_SET_RESERVATION = "set_reservation"
+SERVICE_UPDATE_RESERVATIONS = "update_reservations"
+SERVICE_CLEAR_RESERVATIONS = "clear_reservations"
+SERVICE_REQUEST_RESERVATIONS = "request_reservations"
+
+# Service attributes
+ATTR_ENABLED = "enabled"
+ATTR_DAYS = "days"
+ATTR_HOUR = "hour"
+ATTR_MINUTE = "minute"
+ATTR_OP_MODE = "mode"  # Renamed to avoid conflict with HA's ATTR_MODE
+ATTR_TEMPERATURE = "temperature"
+ATTR_RESERVATIONS = "reservations"
+
+# Valid days of the week
+VALID_DAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"]
+
+# Valid operation modes for reservations
+VALID_MODES = ["heat_pump", "electric", "energy_saver", "high_demand", "vacation", "power_off"]
+
+# Mode mapping for reservations (friendly name -> DHW mode ID)
+MODE_TO_DHW_ID: dict[str, int] = {
+    "heat_pump": 1,
+    "electric": 2,
+    "energy_saver": 3,
+    "high_demand": 4,
+    "vacation": 5,
+    "power_off": 6,
+}
+
+# Service schemas
+SERVICE_SET_RESERVATION_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        vol.Required(ATTR_ENABLED): cv.boolean,
+        vol.Required(ATTR_DAYS): vol.All(cv.ensure_list, [vol.In(VALID_DAYS)]),
+        vol.Required(ATTR_HOUR): vol.All(vol.Coerce(int), vol.Range(min=0, max=23)),
+        vol.Optional(ATTR_MINUTE, default=0): vol.All(vol.Coerce(int), vol.Range(min=0, max=59)),
+        vol.Required(ATTR_OP_MODE): vol.In(VALID_MODES),
+        vol.Optional(ATTR_TEMPERATURE): vol.All(vol.Coerce(float), vol.Range(min=80, max=150)),
+    }
+)
+
+SERVICE_UPDATE_RESERVATIONS_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        vol.Required(ATTR_RESERVATIONS): vol.All(cv.ensure_list),
+        vol.Optional(ATTR_ENABLED, default=True): cv.boolean,
+    }
+)
+
+SERVICE_DEVICE_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+    }
+)
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -41,7 +103,184 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
+    # Register services (only once)
+    await _async_setup_services(hass)
+
     return True
+
+
+async def _async_setup_services(hass: HomeAssistant) -> None:
+    """Set up services for the NWP500 integration."""
+    # Only register once
+    if hass.services.has_service(DOMAIN, SERVICE_SET_RESERVATION):
+        return
+
+    async def _get_coordinator_and_mac(
+        call: ServiceCall,
+    ) -> tuple[NWP500DataUpdateCoordinator, str]:
+        """Get coordinator and MAC address from service call."""
+        device_id = call.data[ATTR_DEVICE_ID]
+        device_registry = dr.async_get(hass)
+        device_entry = device_registry.async_get(device_id)
+
+        if not device_entry:
+            raise HomeAssistantError(f"Device {device_id} not found")
+
+        # Find the coordinator for this device
+        for entry_id, coordinator in hass.data[DOMAIN].items():
+            if not isinstance(coordinator, NWP500DataUpdateCoordinator):
+                continue
+            for mac_address in coordinator.data.keys():
+                # Check if device identifiers match
+                for identifier in device_entry.identifiers:
+                    if identifier[0] == DOMAIN and identifier[1] == mac_address:
+                        return coordinator, mac_address
+
+        raise HomeAssistantError(
+            f"Could not find NWP500 coordinator for device {device_id}"
+        )
+
+    async def async_set_reservation(call: ServiceCall) -> None:
+        """Handle set_reservation service call."""
+        try:
+            from nwp500.encoding import build_reservation_entry
+        except ImportError as err:
+            raise HomeAssistantError(
+                "nwp500-python library not available"
+            ) from err
+
+        coordinator, mac_address = await _get_coordinator_and_mac(call)
+
+        enabled = call.data[ATTR_ENABLED]
+        days = call.data[ATTR_DAYS]
+        hour = call.data[ATTR_HOUR]
+        minute = call.data.get(ATTR_MINUTE, 0)
+        mode = call.data[ATTR_OP_MODE]
+        temperature = call.data.get(ATTR_TEMPERATURE)
+
+        # Convert mode string to DHW mode ID
+        mode_id = MODE_TO_DHW_ID.get(mode)
+        if mode_id is None:
+            raise HomeAssistantError(f"Invalid mode: {mode}")
+
+        # For vacation and power_off modes, temperature is optional
+        if temperature is None:
+            if mode in ("vacation", "power_off"):
+                # Use a default value for non-temperature modes
+                temperature = 120.0
+            else:
+                raise HomeAssistantError(
+                    f"Temperature is required for mode '{mode}'"
+                )
+
+        # Build the reservation entry using library function
+        # Library handles Fahrenheit to half-degrees Celsius conversion
+        reservation = build_reservation_entry(
+            enabled=enabled,
+            days=days,
+            hour=hour,
+            minute=minute,
+            mode_id=mode_id,
+            temperature_f=float(temperature),
+        )
+
+        _LOGGER.info(
+            "Setting reservation for %s: days=%s, time=%02d:%02d, "
+            "mode=%s, temp=%s°F",
+            mac_address,
+            days,
+            hour,
+            minute,
+            mode,
+            temperature,
+        )
+
+        success = await coordinator.async_update_reservations(
+            mac_address, [reservation], enabled=True
+        )
+
+        if not success:
+            raise HomeAssistantError("Failed to set reservation")
+
+    async def async_update_reservations(call: ServiceCall) -> None:
+        """Handle update_reservations service call."""
+        coordinator, mac_address = await _get_coordinator_and_mac(call)
+
+        reservations = call.data[ATTR_RESERVATIONS]
+        enabled = call.data.get(ATTR_ENABLED, True)
+
+        if not isinstance(reservations, list):
+            raise HomeAssistantError("Reservations must be a list")
+
+        _LOGGER.info(
+            "Updating %d reservations for %s (enabled=%s)",
+            len(reservations),
+            mac_address,
+            enabled,
+        )
+
+        success = await coordinator.async_update_reservations(
+            mac_address, reservations, enabled=enabled
+        )
+
+        if not success:
+            raise HomeAssistantError("Failed to update reservations")
+
+    async def async_clear_reservations(call: ServiceCall) -> None:
+        """Handle clear_reservations service call."""
+        coordinator, mac_address = await _get_coordinator_and_mac(call)
+
+        _LOGGER.info("Clearing all reservations for %s", mac_address)
+
+        # Send empty list to clear all reservations
+        success = await coordinator.async_update_reservations(
+            mac_address, [], enabled=False
+        )
+
+        if not success:
+            raise HomeAssistantError("Failed to clear reservations")
+
+    async def async_request_reservations(call: ServiceCall) -> None:
+        """Handle request_reservations service call."""
+        coordinator, mac_address = await _get_coordinator_and_mac(call)
+
+        _LOGGER.info("Requesting reservations for %s", mac_address)
+
+        success = await coordinator.async_request_reservations(mac_address)
+
+        if not success:
+            raise HomeAssistantError("Failed to request reservations")
+
+    # Register all services with schemas
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_RESERVATION,
+        async_set_reservation,
+        schema=SERVICE_SET_RESERVATION_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_UPDATE_RESERVATIONS,
+        async_update_reservations,
+        schema=SERVICE_UPDATE_RESERVATIONS_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CLEAR_RESERVATIONS,
+        async_clear_reservations,
+        schema=SERVICE_DEVICE_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REQUEST_RESERVATIONS,
+        async_request_reservations,
+        schema=SERVICE_DEVICE_SCHEMA,
+    )
+
+    _LOGGER.debug("Registered NWP500 reservation services")
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -51,5 +290,12 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     ):
         coordinator = hass.data[DOMAIN].pop(entry.entry_id)
         await coordinator.async_shutdown()
+
+        # Unregister services if no more entries
+        if not hass.data[DOMAIN]:
+            hass.services.async_remove(DOMAIN, SERVICE_SET_RESERVATION)
+            hass.services.async_remove(DOMAIN, SERVICE_UPDATE_RESERVATIONS)
+            hass.services.async_remove(DOMAIN, SERVICE_CLEAR_RESERVATIONS)
+            hass.services.async_remove(DOMAIN, SERVICE_REQUEST_RESERVATIONS)
 
     return unload_ok

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -13,7 +13,7 @@
   "iot_class": "cloud_polling",
   "quality_scale": "silver",
   "requirements": [
-    "nwp500-python==6.0.7",
+    "nwp500-python==6.1.0",
     "awsiotsdk>=1.25.0"
   ],
   "version": "0.1.1"

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -232,8 +232,8 @@ class NWP500MqttManager:
             elif command == "set_temperature":
                 temp = kwargs.get("temperature")
                 if temp:
-                    await self.mqtt_client.set_dhw_temperature_display(
-                        device, int(temp)
+                    await self.mqtt_client.set_dhw_temperature(
+                        device, float(temp)
                     )
             elif command == "set_dhw_mode":
                 mode = kwargs.get("mode")
@@ -249,6 +249,14 @@ class NWP500MqttManager:
                 await self.mqtt_client.disable_anti_legionella(device)
                 enabled = kwargs.get("enabled", False)
                 await self.mqtt_client.set_tou_enabled(device, enabled)
+            elif command == "update_reservations":
+                reservations = kwargs.get("reservations", [])
+                enabled = kwargs.get("enabled", True)
+                await self.mqtt_client.update_reservations(
+                    device, reservations, enabled=enabled
+                )
+            elif command == "request_reservations":
+                await self.mqtt_client.request_reservations(device)
             else:
                 _LOGGER.error("Unknown command: %s", command)
                 return False

--- a/custom_components/nwp500/services.yaml
+++ b/custom_components/nwp500/services.yaml
@@ -1,0 +1,155 @@
+# Service definitions for Navien NWP500 integration
+
+set_reservation:
+  name: Set Reservation
+  description: >-
+    Create or update a single reservation schedule entry. Reservations allow
+    automatic mode and temperature changes at scheduled times. The device
+    supports up to 7 reservation entries.
+  fields:
+    device_id:
+      name: Device
+      description: The target NWP500 water heater device
+      required: true
+      selector:
+        device:
+          integration: nwp500
+    enabled:
+      name: Enabled
+      description: Whether this reservation entry is active
+      required: true
+      default: true
+      selector:
+        boolean:
+    days:
+      name: Days
+      description: >-
+        Days of the week for this reservation. Select one or more days.
+      required: true
+      selector:
+        select:
+          multiple: true
+          options:
+            - label: Sunday
+              value: Sunday
+            - label: Monday
+              value: Monday
+            - label: Tuesday
+              value: Tuesday
+            - label: Wednesday
+              value: Wednesday
+            - label: Thursday
+              value: Thursday
+            - label: Friday
+              value: Friday
+            - label: Saturday
+              value: Saturday
+    hour:
+      name: Hour
+      description: Hour of day (0-23) when reservation activates
+      required: true
+      selector:
+        number:
+          min: 0
+          max: 23
+          mode: box
+    minute:
+      name: Minute
+      description: Minute of hour (0-59) when reservation activates
+      required: true
+      default: 0
+      selector:
+        number:
+          min: 0
+          max: 59
+          mode: box
+    mode:
+      name: Operation Mode
+      description: DHW operation mode to set when reservation activates
+      required: true
+      selector:
+        select:
+          options:
+            - label: Heat Pump Only
+              value: heat_pump
+            - label: Electric Only
+              value: electric
+            - label: Energy Saver (Hybrid)
+              value: energy_saver
+            - label: High Demand (Hybrid)
+              value: high_demand
+            - label: Vacation
+              value: vacation
+            - label: Power Off
+              value: power_off
+    temperature:
+      name: Temperature
+      description: >-
+        Target temperature in Fahrenheit (80-150°F). Required for heating modes,
+        ignored for vacation and power off modes.
+      required: false
+      selector:
+        number:
+          min: 80
+          max: 150
+          unit_of_measurement: °F
+          mode: slider
+
+update_reservations:
+  name: Update All Reservations
+  description: >-
+    Replace all reservation schedules with a new set. This is an advanced service
+    that allows setting multiple reservations at once. Use set_reservation for
+    simpler single-entry updates.
+  fields:
+    device_id:
+      name: Device
+      description: The target NWP500 water heater device
+      required: true
+      selector:
+        device:
+          integration: nwp500
+    reservations:
+      name: Reservations
+      description: >-
+        List of reservation entries. Each entry should be a dictionary with keys:
+        enable (1=enabled, 2=disabled), week (day bitfield), hour (0-23),
+        min (0-59), mode (1-6), param (temperature in half-degrees Celsius).
+        Use the set_reservation service for a simpler interface.
+      required: true
+      selector:
+        object:
+    enabled:
+      name: System Enabled
+      description: Whether the reservation system is enabled overall
+      required: false
+      default: true
+      selector:
+        boolean:
+
+clear_reservations:
+  name: Clear All Reservations
+  description: Remove all reservation schedules from the device
+  fields:
+    device_id:
+      name: Device
+      description: The target NWP500 water heater device
+      required: true
+      selector:
+        device:
+          integration: nwp500
+
+request_reservations:
+  name: Request Reservations
+  description: >-
+    Request the current reservation schedules from the device. The response
+    will be logged and can be viewed in Home Assistant logs with debug logging
+    enabled for this integration.
+  fields:
+    device_id:
+      name: Device
+      description: The target NWP500 water heater device
+      required: true
+      selector:
+        device:
+          integration: nwp500

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # These dependencies are also listed in custom_components/nwp500/manifest.json
 
 # Core integration library
-nwp500-python==6.0.7
+nwp500-python==6.1.0
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.25.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -149,7 +149,7 @@ def mock_nwp500_mqtt_client() -> Generator[AsyncMock, None, None]:
         client.request_device_info = AsyncMock()
         client.request_device_status = AsyncMock()
         client.set_power = AsyncMock()
-        client.set_dhw_temperature_display = AsyncMock()
+        client.set_dhw_temperature = AsyncMock()
         client.set_dhw_mode = AsyncMock()
         client.on = MagicMock()
         mock_mqtt.return_value = client

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -5,9 +5,17 @@ from __future__ import annotations
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from homeassistant.exceptions import ConfigEntryNotReady
+from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 
-from custom_components.nwp500 import async_setup_entry, async_unload_entry
+from custom_components.nwp500 import (
+    async_setup_entry,
+    async_unload_entry,
+    MODE_TO_DHW_ID,
+    SERVICE_SET_RESERVATION,
+    SERVICE_UPDATE_RESERVATIONS,
+    SERVICE_CLEAR_RESERVATIONS,
+    SERVICE_REQUEST_RESERVATIONS,
+)
 from custom_components.nwp500.const import DOMAIN
 
 
@@ -17,6 +25,32 @@ class TestInit:
     pass
 
 
+class TestModeMapping:
+    """Tests for mode mapping constants."""
+
+    def test_mode_to_dhw_id_contains_all_modes(self):
+        """Test all expected modes are in the mapping."""
+        expected_modes = [
+            "heat_pump",
+            "electric",
+            "energy_saver",
+            "high_demand",
+            "vacation",
+            "power_off",
+        ]
+        for mode in expected_modes:
+            assert mode in MODE_TO_DHW_ID
+
+    def test_mode_values_are_correct(self):
+        """Test mode values match DHW operation setting IDs."""
+        assert MODE_TO_DHW_ID["heat_pump"] == 1
+        assert MODE_TO_DHW_ID["electric"] == 2
+        assert MODE_TO_DHW_ID["energy_saver"] == 3
+        assert MODE_TO_DHW_ID["high_demand"] == 4
+        assert MODE_TO_DHW_ID["vacation"] == 5
+        assert MODE_TO_DHW_ID["power_off"] == 6
+
+
 @pytest.mark.asyncio
 async def test_async_setup_entry_update_failed():
     """Test setup entry handles UpdateFailed correctly."""
@@ -24,6 +58,8 @@ async def test_async_setup_entry_update_failed():
 
     mock_hass = MagicMock()
     mock_hass.data = {}
+    mock_hass.services.has_service = MagicMock(return_value=False)
+    mock_hass.services.async_register = MagicMock()
 
     mock_entry = MagicMock()
     mock_entry.entry_id = "test_entry"
@@ -48,6 +84,8 @@ async def test_async_setup_entry_stores_coordinator():
     mock_hass = MagicMock()
     mock_hass.data = {}
     mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
+    mock_hass.services.has_service = MagicMock(return_value=False)
+    mock_hass.services.async_register = MagicMock()
 
     mock_entry = MagicMock()
     mock_entry.entry_id = "test_entry"
@@ -66,6 +104,65 @@ async def test_async_setup_entry_stores_coordinator():
         assert DOMAIN in mock_hass.data
         assert mock_entry.entry_id in mock_hass.data[DOMAIN]
         assert mock_hass.data[DOMAIN][mock_entry.entry_id] == mock_coordinator
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_services():
+    """Test setup entry registers reservation services."""
+    mock_hass = MagicMock()
+    mock_hass.data = {}
+    mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
+    mock_hass.services.has_service = MagicMock(return_value=False)
+    mock_hass.services.async_register = MagicMock()
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+
+    with patch(
+        "custom_components.nwp500.NWP500DataUpdateCoordinator"
+    ) as mock_coordinator_class:
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator_class.return_value = mock_coordinator
+
+        await async_setup_entry(mock_hass, mock_entry)
+
+        # Verify all 4 services were registered
+        assert mock_hass.services.async_register.call_count == 4
+
+        # Get all service names that were registered
+        registered_services = [
+            call[0][1] for call in mock_hass.services.async_register.call_args_list
+        ]
+        assert SERVICE_SET_RESERVATION in registered_services
+        assert SERVICE_UPDATE_RESERVATIONS in registered_services
+        assert SERVICE_CLEAR_RESERVATIONS in registered_services
+        assert SERVICE_REQUEST_RESERVATIONS in registered_services
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_skips_service_registration_if_exists():
+    """Test setup entry skips registration if services already exist."""
+    mock_hass = MagicMock()
+    mock_hass.data = {}
+    mock_hass.config_entries.async_forward_entry_setups = AsyncMock()
+    mock_hass.services.has_service = MagicMock(return_value=True)
+    mock_hass.services.async_register = MagicMock()
+
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+
+    with patch(
+        "custom_components.nwp500.NWP500DataUpdateCoordinator"
+    ) as mock_coordinator_class:
+        mock_coordinator = MagicMock()
+        mock_coordinator.async_config_entry_first_refresh = AsyncMock()
+        mock_coordinator_class.return_value = mock_coordinator
+
+        await async_setup_entry(mock_hass, mock_entry)
+
+        # Services should not be registered again
+        mock_hass.services.async_register.assert_not_called()
 
 
 @pytest.mark.asyncio
@@ -92,3 +189,26 @@ async def test_async_unload_entry_cleanup():
     mock_coordinator.async_shutdown.assert_called_once()
     # Verify coordinator was removed from hass.data
     assert mock_entry.entry_id not in mock_hass.data[DOMAIN]
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_removes_services_when_last():
+    """Test unload removes services when last entry is unloaded."""
+    mock_hass = MagicMock()
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+
+    # Setup hass.data with only one coordinator (last entry)
+    mock_coordinator = MagicMock()
+    mock_coordinator.async_shutdown = AsyncMock()
+    mock_hass.data = {DOMAIN: {mock_entry.entry_id: mock_coordinator}}
+
+    mock_hass.config_entries.async_unload_platforms = AsyncMock(
+        return_value=True
+    )
+    mock_hass.services.async_remove = MagicMock()
+
+    await async_unload_entry(mock_hass, mock_entry)
+
+    # All 4 services should be removed
+    assert mock_hass.services.async_remove.call_count == 4

--- a/tests/unit/test_mqtt_manager.py
+++ b/tests/unit/test_mqtt_manager.py
@@ -30,7 +30,7 @@ def mock_mqtt_client():
         client.request_device_info = AsyncMock()
         client.request_device_status = AsyncMock()
         client.set_power = AsyncMock()
-        client.set_dhw_temperature_display = AsyncMock()
+        client.set_dhw_temperature = AsyncMock()
         client.set_dhw_mode = AsyncMock()
         client.stop_all_periodic_tasks = AsyncMock()
         client.reset_reconnect = AsyncMock()
@@ -224,3 +224,46 @@ async def test_request_status_consecutive_timeouts(
     mock_mqtt_client.request_device_status.side_effect = None
     await manager.request_status(mock_device)
     assert manager.consecutive_timeouts == 0
+
+
+@pytest.mark.asyncio
+async def test_send_command_update_reservations(
+    manager, mock_mqtt_client, mock_device
+):
+    """Test sending update_reservations command."""
+    await manager.setup()
+
+    # Mock the update_reservations method
+    mock_mqtt_client.update_reservations = AsyncMock()
+
+    reservations = [
+        {"enable": 1, "week": 42, "hour": 6, "min": 30, "mode": 3, "param": 120}
+    ]
+
+    result = await manager.send_command(
+        mock_device,
+        "update_reservations",
+        reservations=reservations,
+        enabled=True,
+    )
+
+    assert result is True
+    mock_mqtt_client.update_reservations.assert_called_once_with(
+        mock_device, reservations, enabled=True
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_command_request_reservations(
+    manager, mock_mqtt_client, mock_device
+):
+    """Test sending request_reservations command."""
+    await manager.setup()
+
+    # Mock the request_reservations method
+    mock_mqtt_client.request_reservations = AsyncMock()
+
+    result = await manager.send_command(mock_device, "request_reservations")
+
+    assert result is True
+    mock_mqtt_client.request_reservations.assert_called_once_with(mock_device)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1,0 +1,326 @@
+"""Tests for NWP500 reservation services."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from homeassistant.core import ServiceCall
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.nwp500 import (
+    ATTR_DAYS,
+    ATTR_DEVICE_ID,
+    ATTR_ENABLED,
+    ATTR_HOUR,
+    ATTR_MINUTE,
+    ATTR_OP_MODE,
+    ATTR_RESERVATIONS,
+    ATTR_TEMPERATURE,
+    _async_setup_services,
+)
+from custom_components.nwp500.const import DOMAIN
+from custom_components.nwp500.coordinator import NWP500DataUpdateCoordinator
+
+
+@pytest.fixture
+def mock_hass():
+    """Create a mock Home Assistant instance."""
+    hass = MagicMock()
+    hass.services.has_service = MagicMock(return_value=False)
+    hass.services.async_register = MagicMock()
+    hass.data = {DOMAIN: {}}
+    return hass
+
+
+@pytest.fixture
+def mock_device_registry():
+    """Create a mock device registry."""
+    with patch(
+        "custom_components.nwp500.dr.async_get"
+    ) as mock_dr:
+        registry = MagicMock()
+        mock_dr.return_value = registry
+        yield registry
+
+
+@pytest.fixture
+def mock_service_call():
+    """Create a mock service call."""
+    call = MagicMock(spec=ServiceCall)
+    call.data = {}
+    return call
+
+
+class TestReservationServices:
+    """Tests for reservation service handlers."""
+
+    @pytest.mark.asyncio
+    async def test_setup_services_registers_all(self, mock_hass):
+        """Test that all 4 services are registered."""
+        await _async_setup_services(mock_hass)
+
+        assert mock_hass.services.async_register.call_count == 4
+
+    @pytest.mark.asyncio
+    async def test_setup_services_skips_if_already_registered(self, mock_hass):
+        """Test that services are not registered twice."""
+        mock_hass.services.has_service = MagicMock(return_value=True)
+
+        await _async_setup_services(mock_hass)
+
+        mock_hass.services.async_register.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_set_reservation_builds_entry_correctly(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test set_reservation builds a proper reservation entry."""
+        # Setup mock coordinator
+        mock_coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        mock_coordinator.async_update_reservations = AsyncMock(return_value=True)
+        mock_hass.data[DOMAIN]["entry_1"] = mock_coordinator
+
+        # Setup device registry
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        await _async_setup_services(mock_hass)
+
+        # Get the set_reservation handler
+        set_reservation_handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == "set_reservation":
+                set_reservation_handler = call[0][2]
+                break
+
+        assert set_reservation_handler is not None
+
+        # Create service call
+        call = MagicMock(spec=ServiceCall)
+        call.data = {
+            ATTR_DEVICE_ID: "device_123",
+            ATTR_ENABLED: True,
+            ATTR_DAYS: ["Monday", "Wednesday", "Friday"],
+            ATTR_HOUR: 6,
+            ATTR_MINUTE: 30,
+            ATTR_OP_MODE: "energy_saver",
+            ATTR_TEMPERATURE: 140,
+        }
+
+        # Mock build_reservation_entry in the encoding module
+        with patch(
+            "nwp500.encoding.build_reservation_entry",
+            return_value={"enable": 1, "week": 42, "hour": 6, "min": 30, "mode": 3, "param": 120},
+        ) as mock_build:
+            await set_reservation_handler(call)
+
+            # Verify build_reservation_entry was called with correct args
+            # Library now takes temperature_f directly instead of param
+            mock_build.assert_called_once_with(
+                enabled=True,
+                days=["Monday", "Wednesday", "Friday"],
+                hour=6,
+                minute=30,
+                mode_id=3,  # energy_saver
+                temperature_f=140.0,  # Fahrenheit directly
+            )
+
+            # Verify coordinator was called
+            mock_coordinator.async_update_reservations.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_set_reservation_invalid_mode_raises_error(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test set_reservation raises error for invalid mode."""
+        mock_coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        mock_hass.data[DOMAIN]["entry_1"] = mock_coordinator
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        await _async_setup_services(mock_hass)
+
+        set_reservation_handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == "set_reservation":
+                set_reservation_handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {
+            ATTR_DEVICE_ID: "device_123",
+            ATTR_ENABLED: True,
+            ATTR_DAYS: ["Monday"],
+            ATTR_HOUR: 6,
+            ATTR_MINUTE: 0,
+            ATTR_OP_MODE: "invalid_mode",
+            ATTR_TEMPERATURE: 120,
+        }
+
+        with pytest.raises(HomeAssistantError, match="Invalid mode"):
+            await set_reservation_handler(call)
+
+    @pytest.mark.asyncio
+    async def test_set_reservation_requires_temp_for_heating_modes(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test set_reservation requires temperature for heating modes."""
+        mock_coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        mock_hass.data[DOMAIN]["entry_1"] = mock_coordinator
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        await _async_setup_services(mock_hass)
+
+        set_reservation_handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == "set_reservation":
+                set_reservation_handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {
+            ATTR_DEVICE_ID: "device_123",
+            ATTR_ENABLED: True,
+            ATTR_DAYS: ["Monday"],
+            ATTR_HOUR: 6,
+            ATTR_MINUTE: 0,
+            ATTR_OP_MODE: "heat_pump",  # Heating mode requires temp
+            # ATTR_TEMPERATURE not provided
+        }
+
+        with pytest.raises(HomeAssistantError, match="Temperature is required"):
+            await set_reservation_handler(call)
+
+    @pytest.mark.asyncio
+    async def test_clear_reservations_sends_empty_list(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test clear_reservations sends empty reservation list."""
+        mock_coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        mock_coordinator.async_update_reservations = AsyncMock(return_value=True)
+        mock_hass.data[DOMAIN]["entry_1"] = mock_coordinator
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        await _async_setup_services(mock_hass)
+
+        clear_handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == "clear_reservations":
+                clear_handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+
+        await clear_handler(call)
+
+        mock_coordinator.async_update_reservations.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF", [], enabled=False
+        )
+
+    @pytest.mark.asyncio
+    async def test_request_reservations_calls_coordinator(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test request_reservations calls coordinator method."""
+        mock_coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        mock_coordinator.async_request_reservations = AsyncMock(return_value=True)
+        mock_hass.data[DOMAIN]["entry_1"] = mock_coordinator
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        await _async_setup_services(mock_hass)
+
+        request_handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == "request_reservations":
+                request_handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+
+        await request_handler(call)
+
+        mock_coordinator.async_request_reservations.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF"
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_reservations_passes_list(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test update_reservations passes reservation list."""
+        mock_coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        mock_coordinator.async_update_reservations = AsyncMock(return_value=True)
+        mock_hass.data[DOMAIN]["entry_1"] = mock_coordinator
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        await _async_setup_services(mock_hass)
+
+        update_handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == "update_reservations":
+                update_handler = call[0][2]
+                break
+
+        reservations = [
+            {"enable": 1, "week": 42, "hour": 6, "min": 30, "mode": 3, "param": 120}
+        ]
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {
+            ATTR_DEVICE_ID: "device_123",
+            ATTR_RESERVATIONS: reservations,
+            ATTR_ENABLED: True,
+        }
+
+        await update_handler(call)
+
+        mock_coordinator.async_update_reservations.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF", reservations, enabled=True
+        )
+
+    @pytest.mark.asyncio
+    async def test_device_not_found_raises_error(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test service raises error when device not found."""
+        mock_hass.data[DOMAIN]["entry_1"] = MagicMock()
+
+        mock_device_registry.async_get = MagicMock(return_value=None)
+
+        await _async_setup_services(mock_hass)
+
+        request_handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == "request_reservations":
+                request_handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "unknown_device"}
+
+        with pytest.raises(HomeAssistantError, match="not found"):
+            await request_handler(call)

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ deps =
     pytest-homeassistant-custom-component>=0.13.0
     pytest-timeout>=2.1.0
     homeassistant>=2024.1.0
-    nwp500-python==6.0.7
+    nwp500-python==6.1.0
     awsiotsdk>=1.25.0
 skip_install = True
 commands =
@@ -30,7 +30,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2024.1.0
-    nwp500-python==6.0.7
+    nwp500-python==6.1.0
     awsiotsdk>=1.25.0
 skip_install = True
 commands =
@@ -41,7 +41,7 @@ description = Run pyright type checking
 deps =
     pyright>=1.1.0
     homeassistant>=2024.1.0
-    nwp500-python==6.0.7
+    nwp500-python==6.1.0
     awsiotsdk>=1.25.0
 skip_install = True
 commands =


### PR DESCRIPTION
## Overview
This PR adds comprehensive reservation schedule management capabilities to the NWP500 integration, allowing users to automate water heater operation mode and temperature changes on a daily schedule.

## Features
- **set_reservation**: Create or update a single reservation entry
- **update_reservations**: Bulk update multiple reservation entries
- **clear_reservations**: Remove all reservation schedules
- **request_reservations**: Fetch current reservation schedules from device

## Service Details
- Support for up to 7 reservation entries per device
- Six operation modes: heat_pump, electric, energy_saver, high_demand, vacation, power_off
- Schedule by day of week (Sunday-Saturday)
- Time-based activation with hour/minute precision
- Temperature setpoint support (80-150°F)

## Implementation
- Added comprehensive service schemas with full validation
- Integrated with MQTT communication layer
- Services accessible via Developer Tools, automations, and scripts
- Added services.yaml for Home Assistant service discovery
- Full test coverage for service handlers

## Files Changed
- custom_components/nwp500/__init__.py - Service registration and handlers
- custom_components/nwp500/coordinator.py - MQTT command wrappers
- custom_components/nwp500/services.yaml - Service definitions
- tests/unit/test_services.py - Service handler tests
- And related dependency/documentation updates