### PR TITLE
Fix MQTT update interval regression

### DIFF
--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -272,8 +272,10 @@ class NWP500MqttManager:
             return False
 
         try:
-            # Use ensure_device_info_cached which triggers status update
-            await self.mqtt_client.ensure_device_info_cached(device)
+            # Request fresh status from device
+            # We use request_device_status to get a lightweight status update
+            # This avoids the caching behavior of ensure_device_info_cached
+            await self.mqtt_client.control.request_device_status(device)
             self.consecutive_timeouts = 0
             return True
         except Exception as err:

--- a/tests/unit/test_mqtt_manager.py
+++ b/tests/unit/test_mqtt_manager.py
@@ -44,6 +44,7 @@ def mock_mqtt_client():
         client.control.update_reservations = AsyncMock()
         client.control.request_reservations = AsyncMock()
         client.control.request_device_status = AsyncMock()
+        client.control.request_device_info = AsyncMock()
 
         mock.return_value = client
         yield client
@@ -224,7 +225,7 @@ async def test_request_status_consecutive_timeouts(
     assert manager.consecutive_timeouts == 0
 
     # 2. Failure should increment counter
-    mock_mqtt_client.ensure_device_info_cached.side_effect = RuntimeError("Timeout")
+    mock_mqtt_client.control.request_device_status.side_effect = RuntimeError("Timeout")
     await manager.request_status(mock_device)
     assert manager.consecutive_timeouts == 1
 
@@ -233,7 +234,7 @@ async def test_request_status_consecutive_timeouts(
     assert manager.consecutive_timeouts == 2
 
     # 4. Success should reset again
-    mock_mqtt_client.ensure_device_info_cached.side_effect = None
+    mock_mqtt_client.control.request_device_status.side_effect = None
     await manager.request_status(mock_device)
     assert manager.consecutive_timeouts == 0
 


### PR DESCRIPTION
This PR fixes a regression where MQTT updates were delayed by up to 5 minutes due to caching. It switches to using `request_device_status` which bypasses the internal cache and forces a fresh status update from the device.