### PR TITLE
fix: rename state attribute to state_province to avoid HA/MQTT conflict

### DIFF
--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -41,6 +41,8 @@ SERVICE_UPDATE_RESERVATIONS = "update_reservations"
 SERVICE_CLEAR_RESERVATIONS = "clear_reservations"
 SERVICE_REQUEST_RESERVATIONS = "request_reservations"
 SERVICE_SET_VACATION_DAYS = "set_vacation_days"
+SERVICE_CONFIGURE_TOU = "configure_tou_schedule"
+SERVICE_REQUEST_TOU = "request_tou_settings"
 
 # Service attributes
 ATTR_ENABLED = "enabled"
@@ -50,6 +52,7 @@ ATTR_MINUTE = "minute"
 ATTR_OP_MODE = "mode"  # Renamed to avoid conflict with HA's ATTR_MODE
 ATTR_TEMPERATURE = "temperature"
 ATTR_RESERVATIONS = "reservations"
+ATTR_PERIODS = "periods"
 
 # Valid days of the week
 VALID_DAYS = [
@@ -165,6 +168,65 @@ SERVICE_SET_VACATION_DAYS_SCHEMA = vol.Schema(
         vol.Required(ATTR_DAYS): vol.All(
             vol.Coerce(int), vol.Range(min=1, max=365)
         ),
+    }
+)
+
+SERVICE_CONFIGURE_TOU_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
+        vol.Required(ATTR_PERIODS): vol.All(
+            cv.ensure_list,
+            vol.Length(max=16),
+            [
+                vol.Schema(
+                    {
+                        vol.Required("season"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0, max=4095),
+                        ),
+                        vol.Required("week"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0, max=127),
+                        ),
+                        vol.Required("start_hour"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0, max=23),
+                        ),
+                        vol.Required("start_minute"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0, max=59),
+                        ),
+                        vol.Required("end_hour"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0, max=23),
+                        ),
+                        vol.Required("end_minute"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0, max=59),
+                        ),
+                        vol.Required("price_min"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0),
+                        ),
+                        vol.Required("price_max"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0),
+                        ),
+                        vol.Required("decimal_point"): vol.All(
+                            vol.Coerce(int),
+                            vol.Range(min=0, max=10),
+                        ),
+                    }
+                )
+            ],
+        ),
+        vol.Optional(ATTR_ENABLED, default=True): cv.boolean,
+    }
+)
+
+SERVICE_REQUEST_TOU_SCHEMA = vol.Schema(
+    {
+        vol.Required(ATTR_DEVICE_ID): cv.string,
     }
 )
 
@@ -335,6 +397,9 @@ class NWP500ServiceHandler:
         if not success:
             raise HomeAssistantError("Failed to set reservation")
 
+        # Auto-refresh stored reservation state
+        await coordinator.async_request_reservations(mac_address)
+
     async def async_update_reservations(self, call: ServiceCall) -> None:
         """Handle update_reservations service call."""
         coordinator, mac_address = await self._get_coordinator_and_mac(call)
@@ -356,6 +421,9 @@ class NWP500ServiceHandler:
         if not success:
             raise HomeAssistantError("Failed to update reservations")
 
+        # Auto-refresh stored reservation state
+        await coordinator.async_request_reservations(mac_address)
+
     async def async_clear_reservations(self, call: ServiceCall) -> None:
         """Handle clear_reservations service call."""
         coordinator, mac_address = await self._get_coordinator_and_mac(call)
@@ -369,6 +437,9 @@ class NWP500ServiceHandler:
 
         if not success:
             raise HomeAssistantError("Failed to clear reservations")
+
+        # Auto-refresh stored reservation state
+        await coordinator.async_request_reservations(mac_address)
 
     async def async_request_reservations(self, call: ServiceCall) -> None:
         """Handle request_reservations service call."""
@@ -393,6 +464,54 @@ class NWP500ServiceHandler:
         )
         if not success:
             raise HomeAssistantError("Failed to set vacation days")
+
+    async def async_configure_tou_schedule(self, call: ServiceCall) -> None:
+        """Handle configure_tou_schedule service call."""
+        coordinator, mac_address = await self._get_coordinator_and_mac(call)
+
+        raw_periods: list[dict[str, Any]] = call.data[ATTR_PERIODS]
+        enabled = call.data[ATTR_ENABLED]
+
+        # Convert HA snake_case keys to library camelCase protocol format
+        periods = [
+            {
+                "season": p["season"],
+                "week": p["week"],
+                "startHour": p["start_hour"],
+                "startMinute": p["start_minute"],
+                "endHour": p["end_hour"],
+                "endMinute": p["end_minute"],
+                "priceMin": p["price_min"],
+                "priceMax": p["price_max"],
+                "decimalPoint": p["decimal_point"],
+            }
+            for p in raw_periods
+        ]
+
+        _LOGGER.info(
+            "Configuring TOU schedule with %d periods for %s (enabled=%s)",
+            len(periods),
+            mac_address,
+            enabled,
+        )
+
+        success = await coordinator.async_configure_tou_schedule(
+            mac_address, periods, enabled=enabled
+        )
+
+        if not success:
+            raise HomeAssistantError("Failed to configure TOU schedule")
+
+    async def async_request_tou_settings(self, call: ServiceCall) -> None:
+        """Handle request_tou_settings service call."""
+        coordinator, mac_address = await self._get_coordinator_and_mac(call)
+
+        _LOGGER.info("Requesting TOU settings for %s", mac_address)
+
+        success = await coordinator.async_request_tou_settings(mac_address)
+
+        if not success:
+            raise HomeAssistantError("Failed to request TOU settings")
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -475,7 +594,21 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
         schema=SERVICE_SET_VACATION_DAYS_SCHEMA,
     )
 
-    _LOGGER.debug("Registered NWP500 reservation services")
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_CONFIGURE_TOU,
+        handler.async_configure_tou_schedule,
+        schema=SERVICE_CONFIGURE_TOU_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_REQUEST_TOU,
+        handler.async_request_tou_settings,
+        schema=SERVICE_REQUEST_TOU_SCHEMA,
+    )
+
+    _LOGGER.debug("Registered NWP500 services")
 
 
 async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
@@ -493,5 +626,7 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, SERVICE_CLEAR_RESERVATIONS)
             hass.services.async_remove(DOMAIN, SERVICE_REQUEST_RESERVATIONS)
             hass.services.async_remove(DOMAIN, SERVICE_SET_VACATION_DAYS)
+            hass.services.async_remove(DOMAIN, SERVICE_CONFIGURE_TOU)
+            hass.services.async_remove(DOMAIN, SERVICE_REQUEST_TOU)
 
     return unload_ok

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -60,6 +60,8 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
         self.devices: list[Device] = []
         self._devices_by_mac: dict[str, Device] = {}  # O(1) device lookup cache
         self.device_features: dict[str, DeviceFeature] = {}
+        self.reservation_schedules: dict[str, dict[str, Any]] = {}
+        self.tou_schedules: dict[str, dict[str, Any]] = {}
         self._reconnect_task: asyncio.Task[Any] | None = (
             None  # Track reconnection task
         )
@@ -604,6 +606,8 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
                 self.auth_client,
                 self._on_device_status_update,
                 self._on_device_feature_update,
+                on_reservation_update=self._on_reservation_update,
+                on_tou_update=self._on_tou_update,
                 unit_system=self.unit_system,
             )
 
@@ -631,6 +635,20 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
                     except Exception as err:
                         _LOGGER.warning(
                             "Failed to request initial device info: %s", err
+                        )
+
+                    # Request initial reservation schedule
+                    try:
+                        await self.mqtt_manager.send_command(
+                            device, "request_reservations"
+                        )
+                        _LOGGER.debug(
+                            "Requested initial reservations for %s",
+                            device.device_info.mac_address,
+                        )
+                    except Exception as err:
+                        _LOGGER.warning(
+                            "Failed to request initial reservations: %s", err
                         )
 
             _LOGGER.info(
@@ -781,6 +799,71 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
         except Exception as err:
             _LOGGER.error("Error handling device feature update: %s", err)
 
+    def _on_reservation_update(
+        self, mac_address: str, response: dict[str, Any]
+    ) -> None:
+        """Handle reservation schedule response from MQTT Manager."""
+        self.hass.loop.call_soon_threadsafe(
+            self._handle_reservation_update_in_loop, mac_address, response
+        )
+
+    def _handle_reservation_update_in_loop(
+        self, mac_address: str, response: dict[str, Any]
+    ) -> None:
+        """Process reservation schedule response within the event loop."""
+        try:
+            _LOGGER.info(
+                "Received reservation schedule for %s", mac_address
+            )
+
+            self.reservation_schedules[mac_address] = response
+
+            # Fire HA event so custom cards and automations can react
+            self.hass.bus.async_fire(
+                "nwp500_reservations_updated",
+                {
+                    "mac_address": mac_address,
+                    "reservation_use": response.get("reservationUse", 0),
+                    "reservations": response.get("reservation", []),
+                },
+            )
+
+            self.async_update_listeners()
+        except Exception as err:
+            _LOGGER.error("Error handling reservation update: %s", err)
+
+    def _on_tou_update(
+        self, mac_address: str, response: dict[str, Any]
+    ) -> None:
+        """Handle TOU schedule response from MQTT Manager."""
+        self.hass.loop.call_soon_threadsafe(
+            self._handle_tou_update_in_loop, mac_address, response
+        )
+
+    def _handle_tou_update_in_loop(
+        self, mac_address: str, response: dict[str, Any]
+    ) -> None:
+        """Process TOU schedule response within the event loop."""
+        try:
+            _LOGGER.info(
+                "Received TOU schedule for %s", mac_address
+            )
+
+            self.tou_schedules[mac_address] = response
+
+            # Fire HA event so custom cards and automations can react
+            self.hass.bus.async_fire(
+                "nwp500_tou_updated",
+                {
+                    "mac_address": mac_address,
+                    "tou_data": response,
+                },
+            )
+
+            self.async_update_listeners()
+        except Exception as err:
+            _LOGGER.error("Error handling TOU update: %s", err)
+
     async def async_control_device(
         self, mac_address: str, command: str, **kwargs: Any
     ) -> bool:
@@ -893,6 +976,93 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
             device, "request_reservations"
         )
 
+    async def async_configure_tou_schedule(
+        self,
+        mac_address: str,
+        periods: list[dict[str, Any]],
+        enabled: bool = True,
+    ) -> bool:
+        """Configure TOU schedule for a device.
+
+        Args:
+            mac_address: Device MAC address
+            periods: List of TOU period entries (built with build_tou_period)
+            enabled: Whether TOU scheduling is enabled
+
+        Returns:
+            True if command was sent successfully
+        """
+        if not self.mqtt_manager:
+            _LOGGER.error("MQTT manager not available")
+            return False
+
+        device = self._devices_by_mac.get(mac_address)
+        if not device:
+            _LOGGER.error("Device %s not found", mac_address)
+            return False
+
+        # Get controller serial number from device features
+        features = self.device_features.get(mac_address)
+        controller_serial = (
+            getattr(features, "controller_serial_number", "")
+            if features
+            else ""
+        )
+        if not controller_serial:
+            _LOGGER.error(
+                "Controller serial number not available for %s. "
+                "Device info may not have been received yet.",
+                mac_address,
+            )
+            return False
+
+        return await self.mqtt_manager.send_command(
+            device,
+            "configure_tou_schedule",
+            controller_serial_number=controller_serial,
+            periods=periods,
+            enabled=enabled,
+        )
+
+    async def async_request_tou_settings(self, mac_address: str) -> bool:
+        """Request current TOU settings from a device.
+
+        Args:
+            mac_address: Device MAC address
+
+        Returns:
+            True if request was sent successfully
+        """
+        if not self.mqtt_manager:
+            _LOGGER.error("MQTT manager not available")
+            return False
+
+        device = self._devices_by_mac.get(mac_address)
+        if not device:
+            _LOGGER.error("Device %s not found", mac_address)
+            return False
+
+        # Get controller serial number from device features
+        features = self.device_features.get(mac_address)
+        controller_serial = (
+            getattr(features, "controller_serial_number", "")
+            if features
+            else ""
+        )
+        if not controller_serial:
+            _LOGGER.error(
+                "Controller serial number not available for %s. "
+                "Device info may not have been received yet.",
+                mac_address,
+            )
+            return False
+
+        return await self.mqtt_manager.send_command(
+            device,
+            "request_tou_settings",
+            controller_serial_number=controller_serial,
+        )
+
     async def async_send_command(
         self, mac_address: str, command: str, **kwargs: Any
     ) -> bool:
@@ -943,6 +1113,8 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
 
         # Clear device features cache to prevent memory leaks
         self.device_features.clear()
+        self.reservation_schedules.clear()
+        self.tou_schedules.clear()
 
     def get_field_unit_safe(self, status: Any, field_name: str) -> str | None:
         """Safely get unit field from device status with standardized error handling.

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -812,9 +812,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Process reservation schedule response within the event loop."""
         try:
-            _LOGGER.info(
-                "Received reservation schedule for %s", mac_address
-            )
+            _LOGGER.info("Received reservation schedule for %s", mac_address)
 
             self.reservation_schedules[mac_address] = response
 
@@ -845,9 +843,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
     ) -> None:
         """Process TOU schedule response within the event loop."""
         try:
-            _LOGGER.info(
-                "Received TOU schedule for %s", mac_address
-            )
+            _LOGGER.info("Received TOU schedule for %s", mac_address)
 
             self.tou_schedules[mac_address] = response
 

--- a/custom_components/nwp500/entity.py
+++ b/custom_components/nwp500/entity.py
@@ -231,7 +231,7 @@ class NWP500Entity(CoordinatorEntity[NWP500DataUpdateCoordinator]):
                 if location.city:
                     attrs["city"] = location.city
                 if location.state:
-                    attrs["state"] = location.state
+                    attrs["state_province"] = location.state
                 if location.latitude:
                     attrs["latitude"] = location.latitude
                 if location.longitude:

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -42,7 +42,8 @@ class NWP500MqttManager:
         auth_client: NavienAuthClient,
         on_status_update: Callable[[str, DeviceStatus], None],
         on_feature_update: Callable[[str, DeviceFeature], None],
-        on_reservation_update: Callable[[str, dict[str, Any]], None] | None = None,
+        on_reservation_update: Callable[[str, dict[str, Any]], None]
+        | None = None,
         on_tou_update: Callable[[str, dict[str, Any]], None] | None = None,
         unit_system: str | None = None,
     ) -> None:
@@ -404,7 +405,9 @@ class NWP500MqttManager:
                 case "request_reservations":
                     await self.mqtt_client.control.request_reservations(device)
                 case "configure_tou_schedule":
-                    controller_serial = kwargs.get("controller_serial_number", "")
+                    controller_serial = kwargs.get(
+                        "controller_serial_number", ""
+                    )
                     periods = kwargs.get("periods", [])
                     enabled = kwargs.get("enabled", True)
                     await self.mqtt_client.control.configure_tou_schedule(
@@ -414,7 +417,9 @@ class NWP500MqttManager:
                         enabled=enabled,
                     )
                 case "request_tou_settings":
-                    controller_serial = kwargs.get("controller_serial_number", "")
+                    controller_serial = kwargs.get(
+                        "controller_serial_number", ""
+                    )
                     await self.mqtt_client.control.request_tou_settings(
                         device,
                         controller_serial_number=controller_serial,

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -42,6 +42,8 @@ class NWP500MqttManager:
         auth_client: NavienAuthClient,
         on_status_update: Callable[[str, DeviceStatus], None],
         on_feature_update: Callable[[str, DeviceFeature], None],
+        on_reservation_update: Callable[[str, dict[str, Any]], None] | None = None,
+        on_tou_update: Callable[[str, dict[str, Any]], None] | None = None,
         unit_system: str | None = None,
     ) -> None:
         """Initialize the MQTT manager."""
@@ -51,6 +53,8 @@ class NWP500MqttManager:
         self.diagnostics: MqttDiagnosticsCollector | None = None
         self._on_status_update_callback = on_status_update
         self._on_feature_update_callback = on_feature_update
+        self._on_reservation_update_callback = on_reservation_update
+        self._on_tou_update_callback = on_tou_update
         self.unit_system = unit_system
 
         # Connection tracking
@@ -251,12 +255,51 @@ class NWP500MqttManager:
                     device, feature
                 ),
             )
+            # Subscribe to scheduling response topics
+            await self._subscribe_scheduling_responses(device)
         except Exception as err:
             _LOGGER.warning(
                 "Failed to subscribe to device %s: %s",
                 device.device_info.mac_address,
                 err,
             )
+
+    async def _subscribe_scheduling_responses(self, device: Device) -> None:
+        """Subscribe to reservation and TOU response topics for a device."""
+        if not self.mqtt_client:
+            return
+
+        device_type = str(device.device_info.device_type)
+        client_id = self.mqtt_client.client_id
+        mac_address = device.device_info.mac_address
+
+        # Subscribe to reservation responses: cmd/{device_type}/{client_id}/res/rsv/rd
+        rsv_topic = f"cmd/{device_type}/{client_id}/res/rsv/rd"
+        await self.mqtt_client.subscribe(
+            rsv_topic,
+            lambda topic, message: self._on_reservation_response(
+                mac_address, topic, message
+            ),
+        )
+        _LOGGER.debug(
+            "Subscribed to reservation responses for %s on %s",
+            mac_address,
+            rsv_topic,
+        )
+
+        # Subscribe to TOU responses: cmd/{device_type}/{client_id}/res/tou/rd
+        tou_topic = f"cmd/{device_type}/{client_id}/res/tou/rd"
+        await self.mqtt_client.subscribe(
+            tou_topic,
+            lambda topic, message: self._on_tou_response(
+                mac_address, topic, message
+            ),
+        )
+        _LOGGER.debug(
+            "Subscribed to TOU responses for %s on %s",
+            mac_address,
+            tou_topic,
+        )
 
     async def start_periodic_requests(self, device: Device) -> None:
         """Start periodic status requests."""
@@ -360,6 +403,22 @@ class NWP500MqttManager:
                     )
                 case "request_reservations":
                     await self.mqtt_client.control.request_reservations(device)
+                case "configure_tou_schedule":
+                    controller_serial = kwargs.get("controller_serial_number", "")
+                    periods = kwargs.get("periods", [])
+                    enabled = kwargs.get("enabled", True)
+                    await self.mqtt_client.control.configure_tou_schedule(
+                        device,
+                        controller_serial_number=controller_serial,
+                        periods=periods,
+                        enabled=enabled,
+                    )
+                case "request_tou_settings":
+                    controller_serial = kwargs.get("controller_serial_number", "")
+                    await self.mqtt_client.control.request_tou_settings(
+                        device,
+                        controller_serial_number=controller_serial,
+                    )
                 case "set_vacation_days":
                     days = kwargs.get("days")
                     if days is not None:
@@ -430,6 +489,38 @@ class NWP500MqttManager:
                 return True
         _LOGGER.error("Error during %s: %s", context, err)
         return False
+
+    def _on_reservation_response(
+        self, mac_address: str, topic: str, message: dict[str, Any]
+    ) -> None:
+        """Handle reservation response from device."""
+        try:
+            _LOGGER.debug(
+                "Received reservation response for %s on %s",
+                mac_address,
+                topic,
+            )
+            response = message.get("response", {})
+            if self._on_reservation_update_callback:
+                self._on_reservation_update_callback(mac_address, response)
+        except Exception as err:
+            _LOGGER.error("Error handling reservation response: %s", err)
+
+    def _on_tou_response(
+        self, mac_address: str, topic: str, message: dict[str, Any]
+    ) -> None:
+        """Handle TOU response from device."""
+        try:
+            _LOGGER.debug(
+                "Received TOU response for %s on %s",
+                mac_address,
+                topic,
+            )
+            response = message.get("response", {})
+            if self._on_tou_update_callback:
+                self._on_tou_update_callback(mac_address, response)
+        except Exception as err:
+            _LOGGER.error("Error handling TOU response: %s", err)
 
     # Event Handlers
     def _on_device_status_event(self, event_data: DeviceStatusEvent) -> None:

--- a/custom_components/nwp500/services.yaml
+++ b/custom_components/nwp500/services.yaml
@@ -143,8 +143,8 @@ request_reservations:
   name: Request Reservations
   description: >-
     Request the current reservation schedules from the device. The response
-    will be logged and can be viewed in Home Assistant logs with debug logging
-    enabled for this integration.
+    will be stored in the coordinator and fired as a
+    nwp500_reservations_updated event.
   fields:
     device_id:
       name: Device
@@ -247,6 +247,55 @@ trigger_recirculation:
   description: >-
     Manually trigger the recirculation pump hot button. Immediately starts
     the recirculation pump to deliver hot water to fixtures.
+  fields:
+    device_id:
+      name: Device
+      description: The target NWP500 water heater device
+      required: true
+      selector:
+        device:
+          integration: nwp500
+
+configure_tou_schedule:
+  name: Configure TOU Schedule
+  description: >-
+    Configure the Time of Use (TOU) pricing schedule on the device.
+    Up to 16 periods can be defined with seasonal, weekly, and
+    time-based pricing information. The device uses this to optimize
+    heating based on electricity rates.
+  fields:
+    device_id:
+      name: Device
+      description: The target NWP500 water heater device
+      required: true
+      selector:
+        device:
+          integration: nwp500
+    periods:
+      name: TOU Periods
+      description: >-
+        List of TOU period entries (max 16). Each entry is a dictionary with
+        keys: season (month bitfield 0-4095), week (day bitfield 0-127),
+        start_hour (0-23), start_minute (0-59), end_hour (0-23),
+        end_minute (0-59), price_min (encoded price), price_max (encoded price),
+        decimal_point (decimal places for price).
+      required: true
+      selector:
+        object:
+    enabled:
+      name: Enabled
+      description: Whether the TOU scheduling system is enabled
+      required: false
+      default: true
+      selector:
+        boolean:
+
+request_tou_settings:
+  name: Request TOU Settings
+  description: >-
+    Request the current Time of Use (TOU) schedule configuration from the
+    device. The response will be stored in the coordinator and fired as a
+    nwp500_tou_updated event.
   fields:
     device_id:
       name: Device

--- a/custom_components/nwp500/strings.json
+++ b/custom_components/nwp500/strings.json
@@ -487,7 +487,7 @@
     },
     "request_reservations": {
       "name": "Request Reservations",
-      "description": "Request the current reservation schedules from the device. The response will be logged and can be viewed in Home Assistant logs with debug logging enabled for this integration.",
+      "description": "Request the current reservation schedules from the device. The response will be stored in the coordinator and fired as a nwp500_reservations_updated event.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -556,6 +556,34 @@
     "trigger_recirculation": {
       "name": "Trigger Recirculation",
       "description": "Manually trigger the recirculation pump hot button. Immediately starts the recirculation pump to deliver hot water to fixtures.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The target NWP500 water heater device"
+        }
+      }
+    },
+    "configure_tou_schedule": {
+      "name": "Configure TOU Schedule",
+      "description": "Configure the Time of Use (TOU) pricing schedule on the device. Up to 16 periods can be defined with seasonal, weekly, and time-based pricing information.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The target NWP500 water heater device"
+        },
+        "periods": {
+          "name": "TOU Periods",
+          "description": "List of TOU period entries with season, week, time, and price fields."
+        },
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether the TOU scheduling system is enabled"
+        }
+      }
+    },
+    "request_tou_settings": {
+      "name": "Request TOU Settings",
+      "description": "Request the current Time of Use (TOU) schedule configuration from the device. The response will be stored and fired as a nwp500_tou_updated event.",
       "fields": {
         "device_id": {
           "name": "Device",

--- a/custom_components/nwp500/translations/en.json
+++ b/custom_components/nwp500/translations/en.json
@@ -453,7 +453,7 @@
         },
         "temperature": {
           "name": "Temperature",
-          "description": "Target temperature in Fahrenheit (80-150°F). Required for heating modes, ignored for vacation and power off modes."
+          "description": "Target temperature in Fahrenheit (80-150\u00b0F). Required for heating modes, ignored for vacation and power off modes."
         }
       }
     },
@@ -487,7 +487,7 @@
     },
     "request_reservations": {
       "name": "Request Reservations",
-      "description": "Request the current reservation schedules from the device. The response will be logged and can be viewed in Home Assistant logs with debug logging enabled for this integration.",
+      "description": "Request the current reservation schedules from the device. The response will be stored in the coordinator and fired as a nwp500_reservations_updated event.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -556,6 +556,34 @@
     "trigger_recirculation": {
       "name": "Trigger Recirculation",
       "description": "Manually trigger the recirculation pump hot button. Immediately starts the recirculation pump to deliver hot water to fixtures.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The target NWP500 water heater device"
+        }
+      }
+    },
+    "configure_tou_schedule": {
+      "name": "Configure TOU Schedule",
+      "description": "Configure the Time of Use (TOU) pricing schedule on the device. Up to 16 periods can be defined with seasonal, weekly, and time-based pricing information.",
+      "fields": {
+        "device_id": {
+          "name": "Device",
+          "description": "The target NWP500 water heater device"
+        },
+        "periods": {
+          "name": "TOU Periods",
+          "description": "List of TOU period entries with season, week, time, and price fields."
+        },
+        "enabled": {
+          "name": "Enabled",
+          "description": "Whether the TOU scheduling system is enabled"
+        }
+      }
+    },
+    "request_tou_settings": {
+      "name": "Request TOU Settings",
+      "description": "Request the current Time of Use (TOU) schedule configuration from the device. The response will be stored and fired as a nwp500_tou_updated event.",
       "fields": {
         "device_id": {
           "name": "Device",

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -127,8 +127,8 @@ async def test_async_setup_entry_registers_services():
 
         await async_setup_entry(mock_hass, mock_entry)
 
-        # Verify all 5 services were registered
-        assert mock_hass.services.async_register.call_count == 5
+        # Verify all 7 services were registered
+        assert mock_hass.services.async_register.call_count == 7
 
         # Get all service names that were registered
         registered_services = [
@@ -211,5 +211,5 @@ async def test_async_unload_entry_removes_services_when_last():
 
     await async_unload_entry(mock_hass, mock_entry)
 
-    # All 5 services should be removed
-    assert mock_hass.services.async_remove.call_count == 5
+    # All 7 services should be removed
+    assert mock_hass.services.async_remove.call_count == 7

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -90,10 +90,10 @@ class TestReservationServices:
 
     @pytest.mark.asyncio
     async def test_setup_services_registers_all(self, mock_hass):
-        """Test that all 5 services are registered."""
+        """Test that all 7 services are registered."""
         await _async_setup_services(mock_hass)
 
-        assert mock_hass.services.async_register.call_count == 5
+        assert mock_hass.services.async_register.call_count == 7
 
     @pytest.mark.asyncio
     async def test_setup_services_skips_if_already_registered(self, mock_hass):


### PR DESCRIPTION
## Problem

The `state` key in entity extra attributes conflicts with Home Assistant's reserved `state` concept (which represents the entity's value). This causes problems especially with MQTT, where `state` refers to the entity value, not a US/location state.

## Fix

Renamed `attrs["state"]` to `attrs["state_province"]` in `entity.py` to clarify it refers to a geographic location state/province.