### PR TITLE
fix: rename state attribute to state_province to avoid HA/MQTT conflict

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- **State attribute conflict**: Renamed `state` extra attribute to `state_province` to avoid conflicts with Home Assistant's reserved `state` concept. The `state` key conflicted with MQTT integration where `state` refers to entity value, not geographic location.
+
 ## [0.2.2] - 2026-02-15
 
 ### Changed

--- a/custom_components/nwp500/entity.py
+++ b/custom_components/nwp500/entity.py
@@ -231,7 +231,7 @@ class NWP500Entity(CoordinatorEntity[NWP500DataUpdateCoordinator]):
                 if location.city:
                     attrs["city"] = location.city
                 if location.state:
-                    attrs["state"] = location.state
+                    attrs["state_province"] = location.state
                 if location.latitude:
                     attrs["latitude"] = location.latitude
                 if location.longitude:


### PR DESCRIPTION
## Problem

The `state` key in entity extra attributes conflicts with Home Assistant's reserved `state` concept (which represents the entity's value). This causes problems especially with MQTT, where `state` refers to the entity value, not a US/location state.

## Fix

Renamed `attrs["state"]` to `attrs["state_province"]` in `entity.py` to clarify it refers to a geographic location state/province.

## Changes
- Renamed `state` attribute to `state_province` in entity.py
- Updated CHANGELOG.md with fix details

## Addresses
- Fixes the state attribute naming conflict
- Resolves PR #63 review comments by isolating this change from unrelated TOU features