### PR TITLE
Adopt nwp500-python 7.4.9 + full code review (bugs, services, blueprints, optimizations)

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==7.4.8` - Core library for Navien device communication
+- `nwp500-python==7.4.9` - Core library for Navien device communication
 - `awsiotsdk>=1.25.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -11,8 +11,8 @@ tox -e mypy
 # Run all tests with coverage
 tox -e coverage
 
-# Run tests on specific Python version (py312 or py313)
-tox -e py313 -- tests/unit/test_sensor.py -v
+# Run tests on specific Python version (py314)
+tox -e py314 -- tests/unit/test_sensor.py -v
 
 # Full validation (type check + tests + coverage)
 tox
@@ -29,7 +29,7 @@ This is a Home Assistant custom component that provides integration for Navien N
   - **GitHub Repository**: https://github.com/eman/nwp500-python
   - **Documentation**: https://nwp500-python.readthedocs.io/en/stable/
   - **PyPI Package**: https://pypi.org/project/nwp500-python/
-  - **Current Version**: 7.4.6 (see `custom_components/nwp500/manifest.json`)
+  - **Current Version**: 7.4.9 (see `custom_components/nwp500/manifest.json`)
   - **Note**: When instructions refer to "adopting a new library version" or "updating the library," they mean updating nwp500-python
 
 ### Home Assistant Integration

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -164,7 +164,7 @@ jobs:
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: codecov-umbrella
           fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install tox
         run: uv tool install tox --with tox-uv
@@ -62,7 +62,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install tox
         run: uv tool install tox --with tox-uv
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install tox
         run: uv tool install tox --with tox-uv
@@ -115,7 +115,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.13"]
+        python-version: ["3.14"]
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -153,7 +153,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v6
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install tox
         run: uv tool install tox --with tox-uv

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2026-04-13
 
 ### Added
 - **5 new device control services**:
@@ -145,8 +145,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Replaced manual list management with `collections.deque(maxlen=20)` for timeout history tracking
   - Automatic circular buffer behavior without manual truncation logic
   - Reduces performance overhead of timeout history operations
-
-## [Unreleased]
 
 ## [0.1.9] - 2026-01-25
 
@@ -672,7 +670,8 @@ This section tracks changes in the nwp500-python library that this integration d
 - Device-based integration with proper device registry support
 - Integration with nwp500-python library v3.1.2
 
-[Unreleased]: https://github.com/eman/ha_nwp500/compare/v0.1.5...HEAD
+[Unreleased]: https://github.com/eman/ha_nwp500/compare/v0.14.0...HEAD
+[0.14.0]: https://github.com/eman/ha_nwp500/compare/v0.3.0...v0.14.0
 [0.1.5]: https://github.com/eman/ha_nwp500/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/eman/ha_nwp500/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/eman/ha_nwp500/compare/v0.1.2...v0.1.3

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Library Dependency: nwp500-python**: Upgraded from 7.4.8 to 7.4.9
+  - **7.4.9 (2026-04-12)**: Bug fixes and dependency updates
+    - Fixed timezone-naive datetime in token expiry checks (uses `datetime.now(UTC)` throughout)
+    - Fixed vacation mode sent wrong MQTT command (`set_vacation_days()` now uses correct `DHW_MODE` command; valid range corrected to 1–30 days)
+    - Fixed duplicate AWS IoT subscribe calls on reconnect
+    - Fixed anti-legionella set-period state preservation (no longer re-enables when feature is off)
+    - Fixed subscription state lost after failed resubscription
+    - Fixed unit system detection returning `None` on timeout
+    - Fixed once-listener becoming permanent with duplicate callbacks
+    - Fixed auth session leaked on client construction failure
+    - Bumped minimum dependency versions: `aiohttp>=3.13.5`, `pydantic>=2.12.5`, `awsiotsdk>=1.28.2`
+    - See [release notes](https://github.com/eman/nwp500-python/releases/tag/v7.4.9) for full details
+
 ## [0.3.0] - 2026-02-21
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **5 new device control services**:
+  - `enable_demand_response`: Enable participation in utility demand response programs
+  - `disable_demand_response`: Disable utility demand response participation
+  - `reset_air_filter`: Reset the air filter maintenance timer after cleaning/replacement
+  - `set_recirculation_mode`: Set recirculation pump mode (Always On / Button / Schedule / Temperature Triggered) with a labeled dropdown UI
+  - `trigger_recirculation`: Manually trigger the recirculation pump hot button
+  - All new services support both `device_id` and `entity_id` target selection
+- **4 new automation blueprints** (in `blueprints/automation/`):
+  - `nwp500_solar_boost`: Switch to High Demand mode when solar generation exceeds a configurable threshold; revert to Eco when it drops
+  - `nwp500_away_mode`: Activate vacation mode when all tracked household members leave; restore normal mode on return
+  - `nwp500_leak_alert`: Send a notification and optionally power off the water heater when a moisture/flood sensor triggers
+  - `nwp500_demand_response`: Enable/disable demand response via a binary sensor (utility signal) or a scheduled time window
+
 ### Changed
 - **Library Dependency: nwp500-python**: Upgraded from 7.4.8 to 7.4.9
   - **7.4.9 (2026-04-12)**: Bug fixes and dependency updates
@@ -20,6 +34,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
     - Fixed auth session leaked on client construction failure
     - Bumped minimum dependency versions: `aiohttp>=3.13.5`, `pydantic>=2.12.5`, `awsiotsdk>=1.28.2`
     - See [release notes](https://github.com/eman/nwp500-python/releases/tag/v7.4.9) for full details
+- **Python requirement**: Upgraded to Python 3.14 (required by Home Assistant 2026.4.0+ which resolves the `aiohttp>=3.13.5` dependency)
+- **Service schemas**: `set_vacation_days` and `configure_tou_schedule` now accept `entity_id` in addition to `device_id` (consistent with all other services)
+- **Recirculation mode UI**: `set_recirculation_mode` service now shows a labelled select dropdown instead of a plain number field
+- **MQTT command logging**: All `send_command()` dispatches now emit a unified debug log entry
+- **Water heater refactor**: Extracted `_control_device()` helper in `water_heater.py`, eliminating repeated boilerplate across `set_temperature`, `set_operation_mode`, `turn_away_mode_on`, and `turn_off`
+
+### Fixed
+- **README version badge**: Updated from 0.2.2 to 0.3.0
+- **Energy capacity sensor classification**: `total_energy_capacity` and `available_energy_capacity` corrected from `device_class=energy / state_class=total` to `device_class=energy_storage / state_class=measurement` — these represent current stored energy (fluctuates), not a cumulative counter
+- **Coordinator null guard**: Added `if not coordinator.data:` check before iterating device keys during service resolution, preventing a crash when coordinator data is not yet populated
+- **Sensor telemetry None guards**: MQTT request/response count sensors now use `.get()` with a fallback of 0 instead of direct dict access, preventing `KeyError` on uninitialized telemetry
+- **Thread safety — connection interruptions**: `_connection_interruptions` changed from a plain `list` to `deque(maxlen=20)`, making it safe for MQTT callback threads and eliminating the manual truncation loop
+- **Private attribute access**: `coordinator.py` now uses the public `mqtt_manager.last_reconnect_time` property instead of accessing `_last_reconnect_time` directly
+- **Silent Future exceptions**: `asyncio.run_coroutine_threadsafe()` calls in MQTT callbacks now attach `.add_done_callback()` error handlers so exceptions are logged rather than silently discarded
+- **MAC address tracking**: `_tracked_mac_addresses` changed from `list` to `set` for O(1) membership checks and to prevent duplicate subscriptions
+- **Local import hoisting**: Repeated local imports of `UnitOfTemperature` and temperature constants inside function bodies moved to module level in `__init__.py`
 
 ## [0.3.0] - 2026-02-21
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Navien NWP500 Water Heater - Home Assistant Integration
 
-**Version**: 0.2.2
+**Version**: 0.3.0
 
 [![CI](https://github.com/eman/ha_nwp500/actions/workflows/ci.yml/badge.svg)](https://github.com/eman/ha_nwp500/actions/workflows/ci.yml)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ action:
 ```
 
 ## Library Version
-This integration uses **nwp500-python v7.4.8**.
+This integration uses **nwp500-python v7.4.9**.
 For version history, see [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python).
 
 ## License

--- a/blueprints/automation/nwp500_away_mode.yaml
+++ b/blueprints/automation/nwp500_away_mode.yaml
@@ -1,0 +1,91 @@
+blueprint:
+  name: NWP500 Away Mode
+  description: >
+    Automatically activate vacation mode on your Navien NWP500 water heater
+    when everyone leaves home, and restore the previous mode when someone
+    returns. Reduces energy consumption during extended absences.
+  domain: automation
+  input:
+    nwp500_entity:
+      name: Water Heater
+      description: The NWP500 water heater entity to control.
+      selector:
+        entity:
+          domain: water_heater
+          integration: nwp500
+
+    tracked_persons:
+      name: People to Track
+      description: >
+        Select the person entities to track. Vacation mode activates when ALL
+        selected people are away from home.
+      selector:
+        entity:
+          domain: person
+          multiple: true
+
+    vacation_days:
+      name: Vacation Duration (Days)
+      description: >
+        Number of days to set for vacation mode (1–365). The device will
+        automatically exit vacation mode after this many days even if the
+        automation does not trigger again.
+      default: 30
+      selector:
+        number:
+          min: 1
+          max: 365
+          step: 1
+          unit_of_measurement: days
+          mode: box
+
+    return_mode:
+      name: Return Operation Mode
+      description: Operation mode to restore when someone comes home.
+      default: energy_saver
+      selector:
+        select:
+          options:
+            - label: Energy Saver (Eco)
+              value: energy_saver
+            - label: Heat Pump Only
+              value: heat_pump
+            - label: High Demand
+              value: high_demand
+            - label: Electric Only
+              value: electric
+
+trigger:
+  - platform: state
+    entity_id: !input tracked_persons
+    id: person_state_change
+
+condition: []
+
+action:
+  - variables:
+      all_away: >
+        {% set persons = expand(trigger.entity_id if trigger.entity_id is string else (trigger.entity_id | list)) %}
+        {{ persons | selectattr('state', 'eq', 'not_home') | list | count == persons | list | count }}
+
+  - choose:
+      - conditions:
+          - condition: template
+            value_template: "{{ all_away }}"
+        sequence:
+          - service: nwp500.set_vacation_days
+            data:
+              entity_id: !input nwp500_entity
+              days: !input vacation_days
+
+      - conditions:
+          - condition: template
+            value_template: "{{ not all_away }}"
+        sequence:
+          - service: water_heater.set_operation_mode
+            target:
+              entity_id: !input nwp500_entity
+            data:
+              operation_mode: !input return_mode
+
+mode: single

--- a/blueprints/automation/nwp500_away_mode.yaml
+++ b/blueprints/automation/nwp500_away_mode.yaml
@@ -27,14 +27,14 @@ blueprint:
     vacation_days:
       name: Vacation Duration (Days)
       description: >
-        Number of days to set for vacation mode (1–365). The device will
+        Number of days to set for vacation mode (1–30). The device will
         automatically exit vacation mode after this many days even if the
         automation does not trigger again.
       default: 30
       selector:
         number:
           min: 1
-          max: 365
+          max: 30
           step: 1
           unit_of_measurement: days
           mode: box
@@ -42,12 +42,12 @@ blueprint:
     return_mode:
       name: Return Operation Mode
       description: Operation mode to restore when someone comes home.
-      default: energy_saver
+      default: eco
       selector:
         select:
           options:
             - label: Energy Saver (Eco)
-              value: energy_saver
+              value: eco
             - label: Heat Pump Only
               value: heat_pump
             - label: High Demand
@@ -65,7 +65,7 @@ condition: []
 action:
   - variables:
       all_away: >
-        {% set persons = expand(trigger.entity_id if trigger.entity_id is string else (trigger.entity_id | list)) %}
+        {% set persons = expand(!input tracked_persons) %}
         {{ persons | selectattr('state', 'eq', 'not_home') | list | count == persons | list | count }}
 
   - choose:

--- a/blueprints/automation/nwp500_demand_response.yaml
+++ b/blueprints/automation/nwp500_demand_response.yaml
@@ -1,0 +1,109 @@
+blueprint:
+  name: NWP500 Demand Response
+  description: >
+    Enable or disable demand response participation on your Navien NWP500
+    water heater based on a utility signal sensor or a time window. When
+    demand response is enabled, the device can respond to utility signals
+    to reduce consumption during peak demand events.
+  domain: automation
+  input:
+    nwp500_entity:
+      name: Water Heater
+      description: The NWP500 water heater entity to control.
+      selector:
+        entity:
+          domain: water_heater
+          integration: nwp500
+
+    control_mode:
+      name: Control Mode
+      description: >
+        Choose how demand response is controlled: by a binary sensor signal
+        from your utility, or by a scheduled time window.
+      default: sensor
+      selector:
+        select:
+          options:
+            - label: Binary Sensor (Utility Signal)
+              value: sensor
+            - label: Time Window (Schedule)
+              value: schedule
+
+    dr_sensor:
+      name: Demand Response Signal Sensor
+      description: >
+        A binary sensor that turns ON when demand response should be enabled
+        (e.g. a utility signal or grid stress indicator). Only used when
+        Control Mode is set to Binary Sensor.
+      default:
+      selector:
+        entity:
+          device_class: power
+
+    window_start:
+      name: Peak Window Start Time
+      description: >
+        Time when the peak demand window begins (demand response enabled).
+        Only used when Control Mode is set to Time Window.
+      default: "14:00:00"
+      selector:
+        time:
+
+    window_end:
+      name: Peak Window End Time
+      description: >
+        Time when the peak demand window ends (demand response disabled).
+        Only used when Control Mode is set to Time Window.
+      default: "19:00:00"
+      selector:
+        time:
+
+trigger:
+  - platform: state
+    entity_id: !input dr_sensor
+    to: "on"
+    id: dr_enable
+
+  - platform: state
+    entity_id: !input dr_sensor
+    to: "off"
+    id: dr_disable
+
+  - platform: time
+    at: !input window_start
+    id: window_open
+
+  - platform: time
+    at: !input window_end
+    id: window_close
+
+variables:
+  control_mode: !input control_mode
+
+action:
+  - choose:
+      - conditions:
+          - condition: or
+            conditions:
+              - condition: template
+                value_template: "{{ trigger.id == 'dr_enable' and control_mode == 'sensor' }}"
+              - condition: template
+                value_template: "{{ trigger.id == 'window_open' and control_mode == 'schedule' }}"
+        sequence:
+          - service: nwp500.enable_demand_response
+            data:
+              entity_id: !input nwp500_entity
+
+      - conditions:
+          - condition: or
+            conditions:
+              - condition: template
+                value_template: "{{ trigger.id == 'dr_disable' and control_mode == 'sensor' }}"
+              - condition: template
+                value_template: "{{ trigger.id == 'window_close' and control_mode == 'schedule' }}"
+        sequence:
+          - service: nwp500.disable_demand_response
+            data:
+              entity_id: !input nwp500_entity
+
+mode: single

--- a/blueprints/automation/nwp500_demand_response.yaml
+++ b/blueprints/automation/nwp500_demand_response.yaml
@@ -35,7 +35,6 @@ blueprint:
         A binary sensor that turns ON when demand response should be enabled
         (e.g. a utility signal or grid stress indicator). Only used when
         Control Mode is set to Binary Sensor.
-      default:
       selector:
         entity:
           device_class: power

--- a/blueprints/automation/nwp500_leak_alert.yaml
+++ b/blueprints/automation/nwp500_leak_alert.yaml
@@ -1,0 +1,81 @@
+blueprint:
+  name: NWP500 Leak Alert
+  description: >
+    Send a notification and optionally power off your Navien NWP500 water
+    heater when a water leak or flood sensor triggers. Helps prevent water
+    damage by providing early warning and automatic shutdown.
+  domain: automation
+  input:
+    nwp500_entity:
+      name: Water Heater
+      description: The NWP500 water heater entity to control.
+      selector:
+        entity:
+          domain: water_heater
+          integration: nwp500
+
+    leak_sensor:
+      name: Leak / Flood Sensor
+      description: >
+        A binary sensor that turns ON when a leak or flood is detected
+        (device_class: moisture).
+      selector:
+        entity:
+          device_class: moisture
+
+    notify_target:
+      name: Notification Service
+      description: >
+        The notification service to call (e.g. notify.mobile_app_my_phone).
+        Leave empty to skip notifications.
+      default: notify.notify
+      selector:
+        text:
+
+    notification_message:
+      name: Notification Message
+      description: Message body sent when a leak is detected.
+      default: "⚠️ Water leak detected near the NWP500 water heater!"
+      selector:
+        text:
+
+    power_off_on_leak:
+      name: Power Off on Leak
+      description: >
+        If enabled, the water heater will be powered off when a leak is
+        detected. This requires manual intervention to restore operation.
+      default: true
+      selector:
+        boolean:
+
+trigger:
+  - platform: state
+    entity_id: !input leak_sensor
+    to: "on"
+
+action:
+  - if:
+      - condition: template
+        value_template: "{{ notify_target != '' }}"
+    then:
+      - service: !input notify_target
+        data:
+          message: !input notification_message
+          title: "NWP500 Leak Alert"
+
+  - if:
+      - condition: template
+        value_template: "{{ power_off_on_leak }}"
+    then:
+      - service: water_heater.set_operation_mode
+        target:
+          entity_id: !input nwp500_entity
+        data:
+          operation_mode: "off"
+
+variables:
+  notify_target: !input notify_target
+  power_off_on_leak: !input power_off_on_leak
+
+mode: single
+max_exceeded: silent

--- a/blueprints/automation/nwp500_solar_boost.yaml
+++ b/blueprints/automation/nwp500_solar_boost.yaml
@@ -69,12 +69,12 @@ blueprint:
     eco_mode:
       name: Eco Operation Mode
       description: Operation mode to revert to when solar generation drops.
-      default: energy_saver
+      default: eco
       selector:
         select:
           options:
             - label: Energy Saver (Eco)
-              value: energy_saver
+              value: eco
             - label: Heat Pump Only
               value: heat_pump
 

--- a/blueprints/automation/nwp500_solar_boost.yaml
+++ b/blueprints/automation/nwp500_solar_boost.yaml
@@ -1,0 +1,114 @@
+blueprint:
+  name: NWP500 Solar Boost
+  description: >
+    Automatically switch your Navien NWP500 water heater to High Demand mode
+    when solar generation exceeds a configurable threshold, maximising free
+    solar energy for water heating. Reverts to Energy Saver (Eco) mode when
+    solar output drops below the threshold.
+  domain: automation
+  input:
+    nwp500_entity:
+      name: Water Heater
+      description: The NWP500 water heater entity to control.
+      selector:
+        entity:
+          domain: water_heater
+          integration: nwp500
+
+    solar_sensor:
+      name: Solar Power Sensor
+      description: >
+        A sensor reporting current solar generation (or net grid export) in
+        Watts. The water heater switches to High Demand when this value exceeds
+        the threshold below.
+      selector:
+        entity:
+          device_class: power
+
+    boost_threshold:
+      name: Boost Threshold (W)
+      description: >
+        Minimum solar power (in Watts) required to activate High Demand mode.
+        A value slightly above your base household consumption is recommended.
+      default: 2000
+      selector:
+        number:
+          min: 100
+          max: 20000
+          step: 100
+          unit_of_measurement: W
+          mode: slider
+
+    drop_threshold:
+      name: Drop Threshold (W)
+      description: >
+        Solar power (in Watts) below which the water heater reverts to Energy
+        Saver mode. Set lower than the Boost Threshold to add hysteresis and
+        avoid rapid mode switching.
+      default: 1500
+      selector:
+        number:
+          min: 0
+          max: 20000
+          step: 100
+          unit_of_measurement: W
+          mode: slider
+
+    boost_mode:
+      name: Boost Operation Mode
+      description: Operation mode to use when solar generation is high.
+      default: high_demand
+      selector:
+        select:
+          options:
+            - label: High Demand
+              value: high_demand
+            - label: Electric Only
+              value: electric
+
+    eco_mode:
+      name: Eco Operation Mode
+      description: Operation mode to revert to when solar generation drops.
+      default: energy_saver
+      selector:
+        select:
+          options:
+            - label: Energy Saver (Eco)
+              value: energy_saver
+            - label: Heat Pump Only
+              value: heat_pump
+
+trigger:
+  - platform: numeric_state
+    entity_id: !input solar_sensor
+    above: !input boost_threshold
+    id: solar_high
+
+  - platform: numeric_state
+    entity_id: !input solar_sensor
+    below: !input drop_threshold
+    id: solar_low
+
+action:
+  - choose:
+      - conditions:
+          - condition: trigger
+            id: solar_high
+        sequence:
+          - service: water_heater.set_operation_mode
+            target:
+              entity_id: !input nwp500_entity
+            data:
+              operation_mode: !input boost_mode
+
+      - conditions:
+          - condition: trigger
+            id: solar_low
+        sequence:
+          - service: water_heater.set_operation_mode
+            target:
+              entity_id: !input nwp500_entity
+            data:
+              operation_mode: !input eco_mode
+
+mode: single

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -12,7 +12,7 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, Platform
+from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, Platform, UnitOfTemperature
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
@@ -24,6 +24,10 @@ from .const import (
     DEFAULT_TEMPERATURE_C,
     DEFAULT_TEMPERATURE_F,
     DOMAIN,
+    MAX_TEMPERATURE_C,
+    MAX_TEMPERATURE_F,
+    MIN_TEMPERATURE_C,
+    MIN_TEMPERATURE_F,
     MODE_TO_DHW_ID,
 )
 from .coordinator import NWP500DataUpdateCoordinator
@@ -58,6 +62,11 @@ SERVICE_REQUEST_RESERVATIONS = "request_reservations"
 SERVICE_SET_VACATION_DAYS = "set_vacation_days"
 SERVICE_CONFIGURE_TOU = "configure_tou_schedule"
 SERVICE_REQUEST_TOU = "request_tou_settings"
+SERVICE_ENABLE_DEMAND_RESPONSE = "enable_demand_response"
+SERVICE_DISABLE_DEMAND_RESPONSE = "disable_demand_response"
+SERVICE_RESET_AIR_FILTER = "reset_air_filter"
+SERVICE_SET_RECIRCULATION_MODE = "set_recirculation_mode"
+SERVICE_TRIGGER_RECIRCULATION = "trigger_recirculation"
 
 # Service attributes
 ATTR_ENABLED = "enabled"
@@ -65,6 +74,7 @@ ATTR_DAYS = "days"
 ATTR_HOUR = "hour"
 ATTR_MINUTE = "minute"
 ATTR_OP_MODE = "mode"  # Renamed to avoid conflict with HA's ATTR_MODE
+ATTR_RECIRCULATION_MODE = "mode"
 ATTR_TEMPERATURE = "temperature"
 ATTR_RESERVATIONS = "reservations"
 ATTR_PERIODS = "periods"
@@ -194,66 +204,74 @@ SERVICE_DEVICE_OR_ENTITY_SCHEMA = vol.All(
     cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
 )
 
-SERVICE_SET_VACATION_DAYS_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_DEVICE_ID): cv.string,
-        vol.Required(ATTR_DAYS): vol.All(
-            vol.Coerce(int), vol.Range(min=1, max=365)
-        ),
-    }
+SERVICE_SET_VACATION_DAYS_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Optional(ATTR_DEVICE_ID): cv.string,
+            vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
+            vol.Required(ATTR_DAYS): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=365)
+            ),
+        }
+    ),
+    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
 )
 
-SERVICE_CONFIGURE_TOU_SCHEMA = vol.Schema(
-    {
-        vol.Required(ATTR_DEVICE_ID): cv.string,
-        vol.Required(ATTR_PERIODS): vol.All(
-            cv.ensure_list,
-            vol.Length(max=16),
-            [
-                vol.Schema(
-                    {
-                        vol.Required("season"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0, max=4095),
-                        ),
-                        vol.Required("week"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0, max=127),
-                        ),
-                        vol.Required("start_hour"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0, max=23),
-                        ),
-                        vol.Required("start_minute"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0, max=59),
-                        ),
-                        vol.Required("end_hour"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0, max=23),
-                        ),
-                        vol.Required("end_minute"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0, max=59),
-                        ),
-                        vol.Required("price_min"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0),
-                        ),
-                        vol.Required("price_max"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0),
-                        ),
-                        vol.Required("decimal_point"): vol.All(
-                            vol.Coerce(int),
-                            vol.Range(min=0, max=10),
-                        ),
-                    }
-                )
-            ],
-        ),
-        vol.Optional(ATTR_ENABLED, default=True): cv.boolean,
-    }
+SERVICE_CONFIGURE_TOU_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Optional(ATTR_DEVICE_ID): cv.string,
+            vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
+            vol.Required(ATTR_PERIODS): vol.All(
+                cv.ensure_list,
+                vol.Length(max=16),
+                [
+                    vol.Schema(
+                        {
+                            vol.Required("season"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0, max=4095),
+                            ),
+                            vol.Required("week"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0, max=127),
+                            ),
+                            vol.Required("start_hour"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0, max=23),
+                            ),
+                            vol.Required("start_minute"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0, max=59),
+                            ),
+                            vol.Required("end_hour"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0, max=23),
+                            ),
+                            vol.Required("end_minute"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0, max=59),
+                            ),
+                            vol.Required("price_min"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0),
+                            ),
+                            vol.Required("price_max"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0),
+                            ),
+                            vol.Required("decimal_point"): vol.All(
+                                vol.Coerce(int),
+                                vol.Range(min=0, max=10),
+                            ),
+                        }
+                    )
+                ],
+            ),
+            vol.Optional(ATTR_ENABLED, default=True): cv.boolean,
+        }
+    ),
+    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
 )
 
 SERVICE_REQUEST_TOU_SCHEMA = vol.All(
@@ -261,6 +279,19 @@ SERVICE_REQUEST_TOU_SCHEMA = vol.All(
         {
             vol.Optional(ATTR_DEVICE_ID): cv.string,
             vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
+        }
+    ),
+    cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
+)
+
+SERVICE_SET_RECIRCULATION_MODE_SCHEMA = vol.All(
+    vol.Schema(
+        {
+            vol.Optional(ATTR_DEVICE_ID): cv.string,
+            vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
+            vol.Required(ATTR_RECIRCULATION_MODE): vol.All(
+                vol.Coerce(int), vol.Range(min=1, max=4)
+            ),
         }
     ),
     cv.has_at_least_one_key(ATTR_DEVICE_ID, ATTR_ENTITY_ID),
@@ -306,7 +337,9 @@ class NWP500ServiceHandler:
         for _entry_id, coordinator in self.hass.data[DOMAIN].items():
             if not isinstance(coordinator, NWP500DataUpdateCoordinator):
                 continue
-            for mac_address in coordinator.data.keys():
+            if not coordinator.data:
+                continue
+            for mac_address in coordinator.data:
                 # Check if device identifiers match
                 for identifier in device_entry.identifiers:
                     if identifier[0] == DOMAIN and identifier[1] == mac_address:
@@ -350,8 +383,6 @@ class NWP500ServiceHandler:
         # For vacation/power_off, we use a default that matches the unit system.
         if temperature is None:
             if mode in ["vacation", "power_off"]:
-                from homeassistant.const import UnitOfTemperature
-
                 temperature = (
                     DEFAULT_TEMPERATURE_C
                     if coordinator.hass.config.units.temperature_unit
@@ -377,15 +408,6 @@ class NWP500ServiceHandler:
             temp_min, temp_max = device_temp_min, device_temp_max
         else:
             # Fallback to hardcoded ranges based on HA unit system
-            from homeassistant.const import UnitOfTemperature
-
-            from .const import (
-                MAX_TEMPERATURE_C,
-                MAX_TEMPERATURE_F,
-                MIN_TEMPERATURE_C,
-                MIN_TEMPERATURE_F,
-            )
-
             if (
                 coordinator.hass.config.units.temperature_unit
                 == UnitOfTemperature.CELSIUS
@@ -576,6 +598,59 @@ class NWP500ServiceHandler:
         if not success:
             raise HomeAssistantError("Failed to request TOU settings")
 
+    async def async_enable_demand_response(self, call: ServiceCall) -> None:
+        """Handle enable_demand_response service call."""
+        coordinator, mac_address = await self._get_coordinator_and_mac(call)
+        _LOGGER.info("Enabling demand response for %s", mac_address)
+        success = await coordinator.async_send_command(
+            mac_address, "enable_demand_response"
+        )
+        if not success:
+            raise HomeAssistantError("Failed to enable demand response")
+
+    async def async_disable_demand_response(self, call: ServiceCall) -> None:
+        """Handle disable_demand_response service call."""
+        coordinator, mac_address = await self._get_coordinator_and_mac(call)
+        _LOGGER.info("Disabling demand response for %s", mac_address)
+        success = await coordinator.async_send_command(
+            mac_address, "disable_demand_response"
+        )
+        if not success:
+            raise HomeAssistantError("Failed to disable demand response")
+
+    async def async_reset_air_filter(self, call: ServiceCall) -> None:
+        """Handle reset_air_filter service call."""
+        coordinator, mac_address = await self._get_coordinator_and_mac(call)
+        _LOGGER.info("Resetting air filter timer for %s", mac_address)
+        success = await coordinator.async_send_command(
+            mac_address, "reset_air_filter"
+        )
+        if not success:
+            raise HomeAssistantError("Failed to reset air filter timer")
+
+    async def async_set_recirculation_mode(self, call: ServiceCall) -> None:
+        """Handle set_recirculation_mode service call."""
+        coordinator, mac_address = await self._get_coordinator_and_mac(call)
+        mode = call.data[ATTR_RECIRCULATION_MODE]
+        _LOGGER.info(
+            "Setting recirculation mode to %d for %s", mode, mac_address
+        )
+        success = await coordinator.async_send_command(
+            mac_address, "set_recirculation_mode", mode=mode
+        )
+        if not success:
+            raise HomeAssistantError("Failed to set recirculation mode")
+
+    async def async_trigger_recirculation(self, call: ServiceCall) -> None:
+        """Handle trigger_recirculation service call."""
+        coordinator, mac_address = await self._get_coordinator_and_mac(call)
+        _LOGGER.info("Triggering recirculation for %s", mac_address)
+        success = await coordinator.async_send_command(
+            mac_address, "trigger_recirculation"
+        )
+        if not success:
+            raise HomeAssistantError("Failed to trigger recirculation")
+
 
 async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     """Set up the NWP500 integration domain (once, before any config entries)."""
@@ -705,6 +780,41 @@ async def _async_setup_services(hass: HomeAssistant) -> None:
         schema=SERVICE_REQUEST_TOU_SCHEMA,
     )
 
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_ENABLE_DEMAND_RESPONSE,
+        handler.async_enable_demand_response,
+        schema=SERVICE_DEVICE_OR_ENTITY_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_DISABLE_DEMAND_RESPONSE,
+        handler.async_disable_demand_response,
+        schema=SERVICE_DEVICE_OR_ENTITY_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_RESET_AIR_FILTER,
+        handler.async_reset_air_filter,
+        schema=SERVICE_DEVICE_OR_ENTITY_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_SET_RECIRCULATION_MODE,
+        handler.async_set_recirculation_mode,
+        schema=SERVICE_SET_RECIRCULATION_MODE_SCHEMA,
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        SERVICE_TRIGGER_RECIRCULATION,
+        handler.async_trigger_recirculation,
+        schema=SERVICE_DEVICE_OR_ENTITY_SCHEMA,
+    )
+
     _LOGGER.debug("Registered NWP500 services")
 
 
@@ -725,5 +835,10 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             hass.services.async_remove(DOMAIN, SERVICE_SET_VACATION_DAYS)
             hass.services.async_remove(DOMAIN, SERVICE_CONFIGURE_TOU)
             hass.services.async_remove(DOMAIN, SERVICE_REQUEST_TOU)
+            hass.services.async_remove(DOMAIN, SERVICE_ENABLE_DEMAND_RESPONSE)
+            hass.services.async_remove(DOMAIN, SERVICE_DISABLE_DEMAND_RESPONSE)
+            hass.services.async_remove(DOMAIN, SERVICE_RESET_AIR_FILTER)
+            hass.services.async_remove(DOMAIN, SERVICE_SET_RECIRCULATION_MODE)
+            hass.services.async_remove(DOMAIN, SERVICE_TRIGGER_RECIRCULATION)
 
     return unload_ok

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -12,7 +12,12 @@ from typing import Any
 import voluptuous as vol
 from homeassistant.components.frontend import add_extra_js_url
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import ATTR_DEVICE_ID, ATTR_ENTITY_ID, Platform, UnitOfTemperature
+from homeassistant.const import (
+    ATTR_DEVICE_ID,
+    ATTR_ENTITY_ID,
+    Platform,
+    UnitOfTemperature,
+)
 from homeassistant.core import HomeAssistant, ServiceCall
 from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -215,7 +215,7 @@ SERVICE_SET_VACATION_DAYS_SCHEMA = vol.All(
             vol.Optional(ATTR_DEVICE_ID): cv.string,
             vol.Optional(ATTR_ENTITY_ID): cv.entity_id,
             vol.Required(ATTR_DAYS): vol.All(
-                vol.Coerce(int), vol.Range(min=1, max=365)
+                vol.Coerce(int), vol.Range(min=1, max=30)
             ),
         }
     ),

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -174,7 +174,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            "uv pip install nwp500-python==7.4.8 awsiotsdk>=1.27.0"
+            "uv pip install nwp500-python==7.4.9 awsiotsdk>=1.28.2"
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/const.py
+++ b/custom_components/nwp500/const.py
@@ -590,17 +590,17 @@ SENSOR_CONFIGS: Final = {
     "total_energy_capacity": {
         "attr": "total_energy_capacity",
         "name": "Total Energy Capacity",
-        "device_class": "energy",
+        "device_class": "energy_storage",
         "unit": "Wh",
-        "state_class": "total",
+        "state_class": "measurement",
         "enabled": False,
     },
     "available_energy_capacity": {
         "attr": "available_energy_capacity",
         "name": "Available Energy Capacity",
-        "device_class": "energy",
+        "device_class": "energy_storage",
         "unit": "Wh",
-        "state_class": "total",
+        "state_class": "measurement",
         "enabled": False,
     },
     # Percentage sensors

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -541,7 +541,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                "uv pip install nwp500-python==7.4.8 awsiotsdk>=1.27.0"
+                "uv pip install nwp500-python==7.4.9 awsiotsdk>=1.28.2"
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -333,9 +333,10 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
                 if self.mqtt_manager:
                     try:
                         # Generate request ID for tracking
-                        request_id = f"{mac_address}_{int(time.time() * 1000)}"
+                        now = time.time()
+                        request_id = f"{mac_address}_{int(now * 1000)}"
                         self._last_request_id = request_id
-                        self._last_request_time = time.time()
+                        self._last_request_time = now
                         self._total_requests_sent += 1
 
                         _LOGGER.debug(

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -420,7 +420,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator):
                         if self._consecutive_timeouts >= 3:
                             elapsed = (
                                 time.time()
-                                - self.mqtt_manager._last_reconnect_time
+                                - self.mqtt_manager.last_reconnect_time
                             )
                             if elapsed < MIN_RECONNECT_INTERVAL:
                                 _LOGGER.debug(

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/eman/ha_nwp500/issues",
   "loggers": ["custom_components.nwp500"],
   "quality_scale": "silver",
-  "requirements": ["nwp500-python==7.4.9", "awsiotsdk>=1.28.2"],
+  "requirements": ["nwp500-python==7.4.9", "awsiotsdk>=1.27.0"],
   "version": "0.14.0"
 }

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -12,5 +12,5 @@
   "loggers": ["custom_components.nwp500"],
   "quality_scale": "silver",
   "requirements": ["nwp500-python==7.4.9", "awsiotsdk>=1.28.2"],
-  "version": "0.3.0"
+  "version": "0.14.0"
 }

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -11,6 +11,6 @@
   "issue_tracker": "https://github.com/eman/ha_nwp500/issues",
   "loggers": ["custom_components.nwp500"],
   "quality_scale": "silver",
-  "requirements": ["nwp500-python==7.4.8", "awsiotsdk>=1.27.0"],
+  "requirements": ["nwp500-python==7.4.9", "awsiotsdk>=1.28.2"],
   "version": "0.3.0"
 }

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -483,10 +483,14 @@ class NWP500MqttManager:
                     await self.mqtt_client.control.reset_air_filter(device)
                 case "set_recirculation_mode":
                     mode = kwargs.get("mode")
-                    if mode is not None:
-                        await self.mqtt_client.control.set_recirculation_mode(
-                            device, int(mode)
+                    if mode is None:
+                        _LOGGER.error(
+                            "set_recirculation_mode requires 'mode' kwarg but none was provided"
                         )
+                        return False
+                    await self.mqtt_client.control.set_recirculation_mode(
+                        device, int(mode)
+                    )
                 case "trigger_recirculation":
                     await self.mqtt_client.control.trigger_recirculation_hot_button(
                         device
@@ -688,11 +692,9 @@ class NWP500MqttManager:
                 self.mqtt_client.reset_reconnect(), self.loop
             )
             future.add_done_callback(
-                lambda f: (
-                    _LOGGER.error("reset_reconnect error: %s", f.exception())
-                    if f.exception()
-                    else None
-                )
+                lambda f: _LOGGER.error("reset_reconnect error: %s", f.exception())
+                if not f.cancelled() and f.exception()
+                else None
             )
 
     def _on_connection_interrupted(self, error: Exception) -> None:
@@ -710,13 +712,9 @@ class NWP500MqttManager:
                 self.loop,
             )
             future.add_done_callback(
-                lambda f: (
-                    _LOGGER.debug(
-                        "record_connection_drop error: %s", f.exception()
-                    )
-                    if f.exception()
-                    else None
-                )
+                lambda f: _LOGGER.debug("record_connection_drop error: %s", f.exception())
+                if not f.cancelled() and f.exception()
+                else None
             )
 
     def _on_connection_resumed(
@@ -733,11 +731,7 @@ class NWP500MqttManager:
                 self.loop,
             )
             future.add_done_callback(
-                lambda f: (
-                    _LOGGER.debug(
-                        "record_connection_success error: %s", f.exception()
-                    )
-                    if f.exception()
-                    else None
-                )
+                lambda f: _LOGGER.debug("record_connection_success error: %s", f.exception())
+                if not f.cancelled() and f.exception()
+                else None
             )

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -692,9 +692,11 @@ class NWP500MqttManager:
                 self.mqtt_client.reset_reconnect(), self.loop
             )
             future.add_done_callback(
-                lambda f: _LOGGER.error("reset_reconnect error: %s", f.exception())
-                if not f.cancelled() and f.exception()
-                else None
+                lambda f: (
+                    _LOGGER.error("reset_reconnect error: %s", f.exception())
+                    if not f.cancelled() and f.exception()
+                    else None
+                )
             )
 
     def _on_connection_interrupted(self, error: Exception) -> None:
@@ -712,9 +714,13 @@ class NWP500MqttManager:
                 self.loop,
             )
             future.add_done_callback(
-                lambda f: _LOGGER.debug("record_connection_drop error: %s", f.exception())
-                if not f.cancelled() and f.exception()
-                else None
+                lambda f: (
+                    _LOGGER.debug(
+                        "record_connection_drop error: %s", f.exception()
+                    )
+                    if not f.cancelled() and f.exception()
+                    else None
+                )
             )
 
     def _on_connection_resumed(
@@ -731,7 +737,11 @@ class NWP500MqttManager:
                 self.loop,
             )
             future.add_done_callback(
-                lambda f: _LOGGER.debug("record_connection_success error: %s", f.exception())
-                if not f.cancelled() and f.exception()
-                else None
+                lambda f: (
+                    _LOGGER.debug(
+                        "record_connection_success error: %s", f.exception()
+                    )
+                    if not f.cancelled() and f.exception()
+                    else None
+                )
             )

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -2,11 +2,11 @@
 
 from __future__ import annotations
 
-from collections import deque
 import asyncio
 import logging
 import time
 import types
+from collections import deque
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
@@ -139,7 +139,10 @@ class NWP500MqttManager:
                     """Patched client to handle AWSIoT SDK callback changes."""
 
                     def _on_connection_resumed_internal(
-                        self, return_code: Any, session_present: Any, **kwargs: Any
+                        self,
+                        return_code: Any,
+                        session_present: Any,
+                        **kwargs: Any,
                     ) -> None:
                         """Handle connection resumed with extra kwargs."""
                         super()._on_connection_resumed_internal(
@@ -469,9 +472,13 @@ class NWP500MqttManager:
                             device, 5, vacation_days=int(days)
                         )
                 case "enable_demand_response":
-                    await self.mqtt_client.control.enable_demand_response(device)
+                    await self.mqtt_client.control.enable_demand_response(
+                        device
+                    )
                 case "disable_demand_response":
-                    await self.mqtt_client.control.disable_demand_response(device)
+                    await self.mqtt_client.control.disable_demand_response(
+                        device
+                    )
                 case "reset_air_filter":
                     await self.mqtt_client.control.reset_air_filter(device)
                 case "set_recirculation_mode":
@@ -681,11 +688,11 @@ class NWP500MqttManager:
                 self.mqtt_client.reset_reconnect(), self.loop
             )
             future.add_done_callback(
-                lambda f: _LOGGER.error(
-                    "reset_reconnect error: %s", f.exception()
+                lambda f: (
+                    _LOGGER.error("reset_reconnect error: %s", f.exception())
+                    if f.exception()
+                    else None
                 )
-                if f.exception()
-                else None
             )
 
     def _on_connection_interrupted(self, error: Exception) -> None:
@@ -703,11 +710,13 @@ class NWP500MqttManager:
                 self.loop,
             )
             future.add_done_callback(
-                lambda f: _LOGGER.debug(
-                    "record_connection_drop error: %s", f.exception()
+                lambda f: (
+                    _LOGGER.debug(
+                        "record_connection_drop error: %s", f.exception()
+                    )
+                    if f.exception()
+                    else None
                 )
-                if f.exception()
-                else None
             )
 
     def _on_connection_resumed(
@@ -724,9 +733,11 @@ class NWP500MqttManager:
                 self.loop,
             )
             future.add_done_callback(
-                lambda f: _LOGGER.debug(
-                    "record_connection_success error: %s", f.exception()
+                lambda f: (
+                    _LOGGER.debug(
+                        "record_connection_success error: %s", f.exception()
+                    )
+                    if f.exception()
+                    else None
                 )
-                if f.exception()
-                else None
             )

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections import deque
 import asyncio
 import logging
 import time
@@ -69,14 +70,13 @@ class NWP500MqttManager:
         self._last_reconnect_time: float = 0.0
 
         # Connection state tracking for diagnostics
-        self._connection_interruptions: list[dict[str, Any]] = []
-        self._max_interruption_history: int = 20
+        self._connection_interruptions: deque[dict[str, Any]] = deque(maxlen=20)
 
         # Track subscribed scheduling response topics to avoid duplicates.
         # Topics are per (device_type, client_id), not per device MAC, so
         # we subscribe once and broadcast responses to all known devices.
         self._subscribed_scheduling_topics: set[str] = set()
-        self._tracked_mac_addresses: list[str] = []
+        self._tracked_mac_addresses: set[str] = set()
 
     async def __aenter__(self) -> NWP500MqttManager:
         """Async context manager entry - set up MQTT connection."""
@@ -97,6 +97,11 @@ class NWP500MqttManager:
         """Return True if MQTT is connected."""
         return self.mqtt_client is not None and self.mqtt_client.is_connected
 
+    @property
+    def last_reconnect_time(self) -> float:
+        """Return the timestamp of the last reconnection attempt."""
+        return self._last_reconnect_time
+
     def get_connection_diagnostics(self) -> dict[str, Any]:
         """Get connection state diagnostics.
 
@@ -110,7 +115,7 @@ class NWP500MqttManager:
             "reconnection_in_progress": self.reconnection_in_progress,
             "reconnect_attempts": self._reconnect_attempts,
             "last_reconnect_time": self._last_reconnect_time,
-            "connection_interruptions": self._connection_interruptions,
+            "connection_interruptions": list(self._connection_interruptions),
         }
 
     async def setup(self) -> bool:
@@ -301,7 +306,7 @@ class NWP500MqttManager:
 
         mac_address = device.device_info.mac_address
         if mac_address not in self._tracked_mac_addresses:
-            self._tracked_mac_addresses.append(mac_address)
+            self._tracked_mac_addresses.add(mac_address)
 
         device_type = str(device.device_info.device_type)
         client_id = self.mqtt_client.client_id
@@ -389,6 +394,7 @@ class NWP500MqttManager:
             return False
 
         try:
+            _LOGGER.debug("Sending command '%s' to device", command)
             match command:
                 case "set_power":
                     await self.mqtt_client.control.set_power(
@@ -455,6 +461,22 @@ class NWP500MqttManager:
                         await self.mqtt_client.control.set_dhw_mode(
                             device, 5, vacation_days=int(days)
                         )
+                case "enable_demand_response":
+                    await self.mqtt_client.control.enable_demand_response(device)
+                case "disable_demand_response":
+                    await self.mqtt_client.control.disable_demand_response(device)
+                case "reset_air_filter":
+                    await self.mqtt_client.control.reset_air_filter(device)
+                case "set_recirculation_mode":
+                    mode = kwargs.get("mode")
+                    if mode is not None:
+                        await self.mqtt_client.control.set_recirculation_mode(
+                            device, int(mode)
+                        )
+                case "trigger_recirculation":
+                    await self.mqtt_client.control.trigger_recirculation_hot_button(
+                        device
+                    )
                 case _:
                     _LOGGER.error("Unknown command: %s", command)
                     return False
@@ -654,16 +676,12 @@ class NWP500MqttManager:
 
     def _on_connection_interrupted(self, error: Exception) -> None:
         """Handle connection interruption event for diagnostics."""
-        # Record interruption in local history for diagnostics
         interruption_event: dict[str, Any] = {
             "timestamp": time.time(),
             "error_type": type(error).__name__,
             "error_message": str(error),
         }
         self._connection_interruptions.append(interruption_event)
-        # Keep only last 20 interruption events
-        if len(self._connection_interruptions) > self._max_interruption_history:
-            self._connection_interruptions.pop(0)
 
         if self.diagnostics:
             asyncio.run_coroutine_threadsafe(

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -72,6 +72,9 @@ class NWP500MqttManager:
         # Connection state tracking for diagnostics
         self._connection_interruptions: deque[dict[str, Any]] = deque(maxlen=20)
 
+        # Lazily-resolved patched MQTT client class (set on first setup())
+        self._patched_client_cls: type | None = None
+
         # Track subscribed scheduling response topics to avoid duplicates.
         # Topics are per (device_type, client_id), not per device MAC, so
         # we subscribe once and broadcast responses to all known devices.
@@ -130,16 +133,20 @@ class NWP500MqttManager:
                 NavienMqttClient,
             )
 
-            class PatchedNavienMqttClient(NavienMqttClient):
-                """Patched client to handle AWSIoT SDK callback changes."""
+            if self._patched_client_cls is None:
 
-                def _on_connection_resumed_internal(
-                    self, return_code: Any, session_present: Any, **kwargs: Any
-                ) -> None:
-                    """Handle connection resumed with extra kwargs."""
-                    super()._on_connection_resumed_internal(
-                        return_code, session_present
-                    )
+                class PatchedNavienMqttClient(NavienMqttClient):
+                    """Patched client to handle AWSIoT SDK callback changes."""
+
+                    def _on_connection_resumed_internal(
+                        self, return_code: Any, session_present: Any, **kwargs: Any
+                    ) -> None:
+                        """Handle connection resumed with extra kwargs."""
+                        super()._on_connection_resumed_internal(
+                            return_code, session_present
+                        )
+
+                self._patched_client_cls = PatchedNavienMqttClient
 
             # Initialize diagnostics collector
             self.diagnostics = MqttDiagnosticsCollector(
@@ -147,7 +154,7 @@ class NWP500MqttManager:
             )
 
             # Token validation deferred to connect() per nwp500-python 7.3.1+
-            self.mqtt_client = PatchedNavienMqttClient(
+            self.mqtt_client = self._patched_client_cls(
                 self.auth_client,
                 unit_system=self.unit_system,  # type: ignore[arg-type]
             )
@@ -670,8 +677,15 @@ class NWP500MqttManager:
             "MQTT reconnection failed (attempt %d). Resetting...", attempt
         )
         if self.mqtt_client:
-            asyncio.run_coroutine_threadsafe(
+            future = asyncio.run_coroutine_threadsafe(
                 self.mqtt_client.reset_reconnect(), self.loop
+            )
+            future.add_done_callback(
+                lambda f: _LOGGER.error(
+                    "reset_reconnect error: %s", f.exception()
+                )
+                if f.exception()
+                else None
             )
 
     def _on_connection_interrupted(self, error: Exception) -> None:
@@ -684,9 +698,16 @@ class NWP500MqttManager:
         self._connection_interruptions.append(interruption_event)
 
         if self.diagnostics:
-            asyncio.run_coroutine_threadsafe(
+            future = asyncio.run_coroutine_threadsafe(
                 self.diagnostics.record_connection_drop(error=error),
                 self.loop,
+            )
+            future.add_done_callback(
+                lambda f: _LOGGER.debug(
+                    "record_connection_drop error: %s", f.exception()
+                )
+                if f.exception()
+                else None
             )
 
     def _on_connection_resumed(
@@ -694,11 +715,18 @@ class NWP500MqttManager:
     ) -> None:
         """Handle connection resume event for diagnostics."""
         if self.diagnostics:
-            asyncio.run_coroutine_threadsafe(
+            future = asyncio.run_coroutine_threadsafe(
                 self.diagnostics.record_connection_success(
                     event_type="resumed",
                     session_present=session_present,
                     return_code=return_code,
                 ),
                 self.loop,
+            )
+            future.add_done_callback(
+                lambda f: _LOGGER.debug(
+                    "record_connection_success error: %s", f.exception()
+                )
+                if f.exception()
+                else None
             )

--- a/custom_components/nwp500/sensor.py
+++ b/custom_components/nwp500/sensor.py
@@ -352,7 +352,8 @@ class NWP500MQTTRequestCountSensor(NWP500DiagnosticSensor):
     def native_value(self) -> int:  # type: ignore[reportIncompatibleVariableOverride,unused-ignore]
         """Return the total number of requests sent."""
         telemetry = self.coordinator.get_mqtt_telemetry()
-        return int(telemetry["total_requests_sent"])
+        value = telemetry.get("total_requests_sent")
+        return int(value) if value is not None else 0
 
 
 class NWP500MQTTResponseCountSensor(NWP500DiagnosticSensor):
@@ -378,7 +379,8 @@ class NWP500MQTTResponseCountSensor(NWP500DiagnosticSensor):
     def native_value(self) -> int:  # type: ignore[reportIncompatibleVariableOverride,unused-ignore]
         """Return the total number of responses received."""
         telemetry = self.coordinator.get_mqtt_telemetry()
-        return int(telemetry["total_responses_received"])
+        value = telemetry.get("total_responses_received")
+        return int(value) if value is not None else 0
 
 
 class NWP500MQTTConnectedSensor(NWP500DiagnosticSensor):

--- a/custom_components/nwp500/services.yaml
+++ b/custom_components/nwp500/services.yaml
@@ -196,9 +196,17 @@ enable_demand_response:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
+          integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
           integration: nwp500
 
 disable_demand_response:
@@ -208,9 +216,17 @@ disable_demand_response:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
+          integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
           integration: nwp500
 
 reset_air_filter:
@@ -222,9 +238,17 @@ reset_air_filter:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
+          integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
           integration: nwp500
 
 set_vacation_days:
@@ -237,9 +261,17 @@ set_vacation_days:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
+          integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
           integration: nwp500
     days:
       name: Days
@@ -260,19 +292,33 @@ set_recirculation_mode:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
           integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
+          integration: nwp500
     mode:
       name: Mode
-      description: Recirculation mode (1-4)
+      description: Recirculation pump operation mode
       required: true
       selector:
-        number:
-          min: 1
-          max: 4
-          mode: box
+        select:
+          options:
+            - label: Always On
+              value: "1"
+            - label: Button / On Demand
+              value: "2"
+            - label: Schedule
+              value: "3"
+            - label: Temperature Triggered
+              value: "4"
 
 trigger_recirculation:
   name: Trigger Recirculation
@@ -283,9 +329,17 @@ trigger_recirculation:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
+          integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
           integration: nwp500
 
 configure_tou_schedule:
@@ -299,9 +353,17 @@ configure_tou_schedule:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
+          integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
           integration: nwp500
     periods:
       name: TOU Periods
@@ -332,7 +394,15 @@ request_tou_settings:
     device_id:
       name: Device
       description: The target NWP500 water heater device
-      required: true
+      required: false
       selector:
         device:
+          integration: nwp500
+    entity_id:
+      name: Entity
+      description: The entity ID of the water heater (alternative to Device ID)
+      required: false
+      selector:
+        entity:
+          domain: water_heater
           integration: nwp500

--- a/custom_components/nwp500/services.yaml
+++ b/custom_components/nwp500/services.yaml
@@ -275,12 +275,12 @@ set_vacation_days:
           integration: nwp500
     days:
       name: Days
-      description: Number of days for vacation mode (1-365)
+      description: Number of days for vacation mode (1-30)
       required: true
       selector:
         number:
           min: 1
-          max: 365
+          max: 30
           mode: box
 
 set_recirculation_mode:

--- a/custom_components/nwp500/strings.json
+++ b/custom_components/nwp500/strings.json
@@ -539,7 +539,7 @@
     },
     "set_vacation_days": {
       "name": "Set Vacation Days",
-      "description": "Configure vacation mode duration. Sets the device to vacation mode for the specified number of days (1-365). Vacation mode reduces energy consumption during extended absences.",
+      "description": "Configure vacation mode duration. Sets the device to vacation mode for the specified number of days (1-30). Vacation mode reduces energy consumption during extended absences.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -551,7 +551,7 @@
         },
         "days": {
           "name": "Days",
-          "description": "Number of days for vacation mode (1-365)"
+          "description": "Number of days for vacation mode (1-30)"
         }
       }
     },

--- a/custom_components/nwp500/strings.json
+++ b/custom_components/nwp500/strings.json
@@ -502,6 +502,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -512,6 +516,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -522,6 +530,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -532,6 +544,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         },
         "days": {
           "name": "Days",
@@ -547,9 +563,13 @@
           "name": "Device",
           "description": "The target NWP500 water heater device"
         },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
+        },
         "mode": {
           "name": "Mode",
-          "description": "Recirculation mode (1-4)"
+          "description": "Recirculation pump operation mode: 1=Always On, 2=Button/On Demand, 3=Schedule, 4=Temperature Triggered"
         }
       }
     },
@@ -560,6 +580,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },

--- a/custom_components/nwp500/translations/en.json
+++ b/custom_components/nwp500/translations/en.json
@@ -539,7 +539,7 @@
     },
     "set_vacation_days": {
       "name": "Set Vacation Days",
-      "description": "Configure vacation mode duration. Sets the device to vacation mode for the specified number of days (1-365). Vacation mode reduces energy consumption during extended absences.",
+      "description": "Configure vacation mode duration. Sets the device to vacation mode for the specified number of days (1-30). Vacation mode reduces energy consumption during extended absences.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -551,7 +551,7 @@
         },
         "days": {
           "name": "Days",
-          "description": "Number of days for vacation mode (1-365)"
+          "description": "Number of days for vacation mode (1-30)"
         }
       }
     },

--- a/custom_components/nwp500/translations/en.json
+++ b/custom_components/nwp500/translations/en.json
@@ -502,6 +502,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -512,6 +516,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -522,6 +530,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -532,6 +544,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         },
         "days": {
           "name": "Days",
@@ -547,9 +563,13 @@
           "name": "Device",
           "description": "The target NWP500 water heater device"
         },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
+        },
         "mode": {
           "name": "Mode",
-          "description": "Recirculation mode (1-4)"
+          "description": "Recirculation pump operation mode: 1=Always On, 2=Button/On Demand, 3=Schedule, 4=Temperature Triggered"
         }
       }
     },
@@ -560,6 +580,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },

--- a/custom_components/nwp500/water_heater.py
+++ b/custom_components/nwp500/water_heater.py
@@ -313,6 +313,19 @@ class NWP500WaterHeater(NWP500Entity, WaterHeaterEntity):  # type: ignore[report
 
         return attrs
 
+    async def _control_device(
+        self, command: str, error_message: str, **kwargs: Any
+    ) -> bool:
+        """Send a command and request refresh on success, log error on failure."""
+        success = await self.coordinator.async_control_device(
+            self.mac_address, command, **kwargs
+        )
+        if success:
+            await self.coordinator.async_request_refresh()
+        else:
+            _LOGGER.error(error_message)
+        return success
+
     async def async_set_temperature(self, **kwargs: Any) -> None:
         """Set new target temperature.
 
@@ -333,21 +346,17 @@ class NWP500WaterHeater(NWP500Entity, WaterHeaterEntity):  # type: ignore[report
             )
             return
 
-        success = await self.coordinator.async_control_device(
-            self.mac_address, "set_temperature", temperature=float(temperature)
+        await self._control_device(
+            "set_temperature",
+            "Failed to set temperature",
+            temperature=float(temperature),
         )
-
-        if success:
-            # Trigger immediate data refresh
-            await self.coordinator.async_request_refresh()
 
     async def async_set_operation_mode(self, operation_mode: str) -> None:
         """Set new operation mode using DHW mode control."""
-        # Map Home Assistant operation mode to DHW mode value
         dhw_mode_value = HA_TO_DHW_MODE.get(operation_mode)
 
         if dhw_mode_value is None:
-            # Check if this is an "off" request
             if operation_mode.lower() == STATE_OFF:
                 await self.async_turn_off()
                 return
@@ -359,18 +368,14 @@ class NWP500WaterHeater(NWP500Entity, WaterHeaterEntity):  # type: ignore[report
             "Setting DHW mode to %s (value: %d)", operation_mode, dhw_mode_value
         )
 
-        success = await self.coordinator.async_control_device(
-            self.mac_address, "set_dhw_mode", mode=dhw_mode_value
+        await self._control_device(
+            "set_dhw_mode",
+            f"Failed to set operation mode to {operation_mode}",
+            mode=dhw_mode_value,
         )
-
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.error("Failed to set operation mode to %s", operation_mode)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
         """Turn the water heater on by setting it to energy saver mode."""
-        # When turning "on", set to energy saver (eco) mode as default
         await self.async_set_operation_mode(STATE_ECO)
 
     async def async_turn_away_mode_on(self) -> None:
@@ -378,16 +383,11 @@ class NWP500WaterHeater(NWP500Entity, WaterHeaterEntity):  # type: ignore[report
         # Vacation mode is handled separately from operation modes
         # since it's not in operation_list. This follows HA design
         # where away_mode is a dedicated feature, not an op mode
-        success = await self.coordinator.async_control_device(
-            self.mac_address,
+        await self._control_device(
             "set_dhw_mode",
+            "Failed to set vacation mode",
             mode=5,  # VACATION mode
         )
-
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.error("Failed to set vacation mode")
 
     async def async_turn_away_mode_off(self) -> None:
         """Turn away mode off by returning to eco mode."""
@@ -397,13 +397,8 @@ class NWP500WaterHeater(NWP500Entity, WaterHeaterEntity):  # type: ignore[report
         """Turn the water heater off by setting to power off mode."""
         # Use DHW mode 6 (POWER_OFF) instead of the uncertain set_power method
         # This maps to the "off" operation mode in our DHW_MODE_TO_HA mapping
-        success = await self.coordinator.async_control_device(
-            self.mac_address,
+        await self._control_device(
             "set_dhw_mode",
+            "Failed to set water heater to power off mode",
             mode=6,  # POWER_OFF mode
         )
-
-        if success:
-            await self.coordinator.async_request_refresh()
-        else:
-            _LOGGER.error("Failed to set water heater to power off mode")

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Usage: uv pip install -r requirements.txt
 # Core integration library
-nwp500-python==7.4.8
+nwp500-python==7.4.9
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.27.0

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -11,10 +11,15 @@ from custom_components.nwp500 import (
     MODE_TO_DHW_ID,
     SERVICE_CLEAR_RESERVATIONS,
     SERVICE_CONFIGURE_TOU,
+    SERVICE_DISABLE_DEMAND_RESPONSE,
+    SERVICE_ENABLE_DEMAND_RESPONSE,
     SERVICE_REQUEST_RESERVATIONS,
     SERVICE_REQUEST_TOU,
+    SERVICE_RESET_AIR_FILTER,
+    SERVICE_SET_RECIRCULATION_MODE,
     SERVICE_SET_RESERVATION,
     SERVICE_SET_VACATION_DAYS,
+    SERVICE_TRIGGER_RECIRCULATION,
     SERVICE_UPDATE_RESERVATIONS,
     async_setup_entry,
     async_unload_entry,
@@ -130,8 +135,8 @@ async def test_async_setup_entry_registers_services():
 
         await async_setup_entry(mock_hass, mock_entry)
 
-        # Verify all 7 services were registered
-        assert mock_hass.services.async_register.call_count == 7
+        # Verify all 12 services were registered
+        assert mock_hass.services.async_register.call_count == 12
 
         # Get all service names that were registered
         registered_services = [
@@ -145,6 +150,11 @@ async def test_async_setup_entry_registers_services():
         assert SERVICE_SET_VACATION_DAYS in registered_services
         assert SERVICE_CONFIGURE_TOU in registered_services
         assert SERVICE_REQUEST_TOU in registered_services
+        assert SERVICE_ENABLE_DEMAND_RESPONSE in registered_services
+        assert SERVICE_DISABLE_DEMAND_RESPONSE in registered_services
+        assert SERVICE_RESET_AIR_FILTER in registered_services
+        assert SERVICE_SET_RECIRCULATION_MODE in registered_services
+        assert SERVICE_TRIGGER_RECIRCULATION in registered_services
 
 
 @pytest.mark.asyncio
@@ -217,5 +227,5 @@ async def test_async_unload_entry_removes_services_when_last():
 
     await async_unload_entry(mock_hass, mock_entry)
 
-    # All 7 services should be removed
-    assert mock_hass.services.async_remove.call_count == 7
+    # All 12 services should be removed
+    assert mock_hass.services.async_remove.call_count == 12

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -21,10 +21,15 @@ from custom_components.nwp500 import (
     ATTR_TEMPERATURE,
     SERVICE_CLEAR_RESERVATIONS,
     SERVICE_CONFIGURE_TOU,
+    SERVICE_DISABLE_DEMAND_RESPONSE,
+    SERVICE_ENABLE_DEMAND_RESPONSE,
     SERVICE_REQUEST_RESERVATIONS,
     SERVICE_REQUEST_TOU,
+    SERVICE_RESET_AIR_FILTER,
+    SERVICE_SET_RECIRCULATION_MODE,
     SERVICE_SET_RESERVATION,
     SERVICE_SET_VACATION_DAYS,
+    SERVICE_TRIGGER_RECIRCULATION,
     SERVICE_UPDATE_RESERVATIONS,
     _async_setup_services,
     validate_reservation_temperature,
@@ -98,10 +103,10 @@ class TestReservationServices:
 
     @pytest.mark.asyncio
     async def test_setup_services_registers_all(self, mock_hass):
-        """Test that all 7 services are registered."""
+        """Test that all 12 services are registered."""
         await _async_setup_services(mock_hass)
 
-        assert mock_hass.services.async_register.call_count == 7
+        assert mock_hass.services.async_register.call_count == 12
 
         # Verify all expected services are registered
         registered_services = [
@@ -115,6 +120,11 @@ class TestReservationServices:
         assert SERVICE_SET_VACATION_DAYS in registered_services
         assert SERVICE_CONFIGURE_TOU in registered_services
         assert SERVICE_REQUEST_TOU in registered_services
+        assert SERVICE_ENABLE_DEMAND_RESPONSE in registered_services
+        assert SERVICE_DISABLE_DEMAND_RESPONSE in registered_services
+        assert SERVICE_RESET_AIR_FILTER in registered_services
+        assert SERVICE_SET_RECIRCULATION_MODE in registered_services
+        assert SERVICE_TRIGGER_RECIRCULATION in registered_services
 
     @pytest.mark.asyncio
     async def test_setup_services_skips_if_already_registered(self, mock_hass):
@@ -745,4 +755,231 @@ class TestTouAndVacationServices:
         call = MagicMock(spec=ServiceCall)
         call.data = {ATTR_DEVICE_ID: "device_123"}
         with pytest.raises(HomeAssistantError, match="Failed to request TOU"):
+            await handler(call)
+
+
+class TestDemandResponseAndRecirculationServices:
+    """Tests for demand response and recirculation services."""
+
+    @pytest.fixture(autouse=True)
+    def setup(self, mock_hass, mock_device_registry):
+        """Set up common test fixtures."""
+        self.mock_hass = mock_hass
+        self.mock_device_registry = mock_device_registry
+        self.mock_coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        self.mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        mock_hass.data[DOMAIN]["entry_1"] = self.mock_coordinator
+
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+    @pytest.mark.asyncio
+    async def test_enable_demand_response_calls_coordinator(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test enable_demand_response calls coordinator."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=True)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_ENABLE_DEMAND_RESPONSE:
+                handler = call[0][2]
+                break
+
+        assert handler is not None
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        await handler(call)
+
+        self.mock_coordinator.async_send_command.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF", "enable_demand_response"
+        )
+
+    @pytest.mark.asyncio
+    async def test_enable_demand_response_raises_on_failure(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test enable_demand_response raises HomeAssistantError on failure."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=False)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_ENABLE_DEMAND_RESPONSE:
+                handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        with pytest.raises(HomeAssistantError, match="Failed to enable demand response"):
+            await handler(call)
+
+    @pytest.mark.asyncio
+    async def test_disable_demand_response_calls_coordinator(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test disable_demand_response calls coordinator."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=True)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_DISABLE_DEMAND_RESPONSE:
+                handler = call[0][2]
+                break
+
+        assert handler is not None
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        await handler(call)
+
+        self.mock_coordinator.async_send_command.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF", "disable_demand_response"
+        )
+
+    @pytest.mark.asyncio
+    async def test_disable_demand_response_raises_on_failure(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test disable_demand_response raises HomeAssistantError on failure."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=False)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_DISABLE_DEMAND_RESPONSE:
+                handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        with pytest.raises(HomeAssistantError, match="Failed to disable demand response"):
+            await handler(call)
+
+    @pytest.mark.asyncio
+    async def test_reset_air_filter_calls_coordinator(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test reset_air_filter calls coordinator."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=True)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_RESET_AIR_FILTER:
+                handler = call[0][2]
+                break
+
+        assert handler is not None
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        await handler(call)
+
+        self.mock_coordinator.async_send_command.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF", "reset_air_filter"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reset_air_filter_raises_on_failure(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test reset_air_filter raises HomeAssistantError on failure."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=False)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_RESET_AIR_FILTER:
+                handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        with pytest.raises(HomeAssistantError, match="Failed to reset air filter"):
+            await handler(call)
+
+    @pytest.mark.asyncio
+    async def test_set_recirculation_mode_calls_coordinator(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test set_recirculation_mode calls coordinator with correct mode."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=True)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_SET_RECIRCULATION_MODE:
+                handler = call[0][2]
+                break
+
+        assert handler is not None
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123", "mode": 2}
+        await handler(call)
+
+        self.mock_coordinator.async_send_command.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF", "set_recirculation_mode", mode=2
+        )
+
+    @pytest.mark.asyncio
+    async def test_set_recirculation_mode_raises_on_failure(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test set_recirculation_mode raises HomeAssistantError on failure."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=False)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_SET_RECIRCULATION_MODE:
+                handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123", "mode": 1}
+        with pytest.raises(HomeAssistantError, match="Failed to set recirculation mode"):
+            await handler(call)
+
+    @pytest.mark.asyncio
+    async def test_trigger_recirculation_calls_coordinator(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test trigger_recirculation calls coordinator."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=True)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_TRIGGER_RECIRCULATION:
+                handler = call[0][2]
+                break
+
+        assert handler is not None
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        await handler(call)
+
+        self.mock_coordinator.async_send_command.assert_called_once_with(
+            "AA:BB:CC:DD:EE:FF", "trigger_recirculation"
+        )
+
+    @pytest.mark.asyncio
+    async def test_trigger_recirculation_raises_on_failure(
+        self, mock_hass, mock_device_registry
+    ):
+        """Test trigger_recirculation raises HomeAssistantError on failure."""
+        self.mock_coordinator.async_send_command = AsyncMock(return_value=False)
+        await _async_setup_services(mock_hass)
+
+        handler = None
+        for call in mock_hass.services.async_register.call_args_list:
+            if call[0][1] == SERVICE_TRIGGER_RECIRCULATION:
+                handler = call[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {ATTR_DEVICE_ID: "device_123"}
+        with pytest.raises(HomeAssistantError, match="Failed to trigger recirculation"):
             await handler(call)

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -813,7 +813,9 @@ class TestDemandResponseAndRecirculationServices:
 
         call = MagicMock(spec=ServiceCall)
         call.data = {ATTR_DEVICE_ID: "device_123"}
-        with pytest.raises(HomeAssistantError, match="Failed to enable demand response"):
+        with pytest.raises(
+            HomeAssistantError, match="Failed to enable demand response"
+        ):
             await handler(call)
 
     @pytest.mark.asyncio
@@ -855,7 +857,9 @@ class TestDemandResponseAndRecirculationServices:
 
         call = MagicMock(spec=ServiceCall)
         call.data = {ATTR_DEVICE_ID: "device_123"}
-        with pytest.raises(HomeAssistantError, match="Failed to disable demand response"):
+        with pytest.raises(
+            HomeAssistantError, match="Failed to disable demand response"
+        ):
             await handler(call)
 
     @pytest.mark.asyncio
@@ -897,7 +901,9 @@ class TestDemandResponseAndRecirculationServices:
 
         call = MagicMock(spec=ServiceCall)
         call.data = {ATTR_DEVICE_ID: "device_123"}
-        with pytest.raises(HomeAssistantError, match="Failed to reset air filter"):
+        with pytest.raises(
+            HomeAssistantError, match="Failed to reset air filter"
+        ):
             await handler(call)
 
     @pytest.mark.asyncio
@@ -939,7 +945,9 @@ class TestDemandResponseAndRecirculationServices:
 
         call = MagicMock(spec=ServiceCall)
         call.data = {ATTR_DEVICE_ID: "device_123", "mode": 1}
-        with pytest.raises(HomeAssistantError, match="Failed to set recirculation mode"):
+        with pytest.raises(
+            HomeAssistantError, match="Failed to set recirculation mode"
+        ):
             await handler(call)
 
     @pytest.mark.asyncio
@@ -981,5 +989,7 @@ class TestDemandResponseAndRecirculationServices:
 
         call = MagicMock(spec=ServiceCall)
         call.data = {ATTR_DEVICE_ID: "device_123"}
-        with pytest.raises(HomeAssistantError, match="Failed to trigger recirculation"):
+        with pytest.raises(
+            HomeAssistantError, match="Failed to trigger recirculation"
+        ):
             await handler(call)

--- a/tox.ini
+++ b/tox.ini
@@ -26,8 +26,6 @@ deps =
     homeassistant>=2026.4.0
     nwp500-python==7.4.9
 commands_pre =
-    python -m pip install awsiotsdk>=1.28.2
-    python -m pip install nwp500-python==7.4.9 --no-deps
 
 [testenv:basedpyright]
 description = Run basedpyright type checking
@@ -36,8 +34,6 @@ deps =
     homeassistant>=2026.4.0
     nwp500-python==7.4.9
 commands_pre =
-    python -m pip install awsiotsdk>=1.28.2
-    python -m pip install nwp500-python==7.4.9 --no-deps
 
 [testenv:ruff]
 description = Run ruff linting and formatting checks

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py313,mypy,basedpyright,ruff,coverage,hacs
+envlist = py314,mypy,basedpyright,ruff,coverage,hacs
 skipsdist = True
 runner = uv-venv
 
@@ -9,29 +9,29 @@ deps =
     pytest>=7.0.0
     pytest-asyncio>=0.21.0
     pytest-cov>=4.0.0
-    pytest-homeassistant-custom-component>=0.13.0
+    pytest-homeassistant-custom-component>=0.13.323
     pytest-timeout>=2.1.0
-    pycares<5.0.0
-    homeassistant>=2025.1.0
-    nwp500-python==7.4.8
+commands_pre =
+    python -m pip install awsiotsdk>=1.28.2
+    python -m pip install nwp500-python==7.4.9 --no-deps
 
-[testenv:py313]
-description = Run tests on Python 3.13
-basepython = python3.13
+[testenv:py314]
+description = Run tests on Python 3.14
+basepython = python3.14
 
 [testenv:mypy]
 description = Run mypy type checking
 deps =
     mypy>=1.0.0
-    homeassistant>=2025.1.0
-    nwp500-python==7.4.8
+    homeassistant>=2026.4.0
+    nwp500-python==7.4.9
 
 [testenv:basedpyright]
 description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
-    homeassistant>=2025.1.0
-    nwp500-python==7.4.8
+    homeassistant>=2026.4.0
+    nwp500-python==7.4.9
 
 [testenv:ruff]
 description = Run ruff linting and formatting checks
@@ -44,7 +44,7 @@ commands =
 
 [testenv:coverage]
 description = Run tests and generate coverage report
-basepython = python3
+basepython = python3.14
 deps =
     {[testenv]deps}
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -25,6 +25,9 @@ deps =
     mypy>=1.0.0
     homeassistant>=2026.4.0
     nwp500-python==7.4.9
+commands_pre =
+    python -m pip install awsiotsdk>=1.28.2
+    python -m pip install nwp500-python==7.4.9 --no-deps
 
 [testenv:basedpyright]
 description = Run basedpyright type checking
@@ -32,12 +35,16 @@ deps =
     basedpyright>=1.0.0
     homeassistant>=2026.4.0
     nwp500-python==7.4.9
+commands_pre =
+    python -m pip install awsiotsdk>=1.28.2
+    python -m pip install nwp500-python==7.4.9 --no-deps
 
 [testenv:ruff]
 description = Run ruff linting and formatting checks
 deps =
     ruff>=0.1.0
 skip_install = True
+commands_pre =
 commands =
     ruff check custom_components/nwp500 tests scripts
     ruff format --check custom_components/nwp500 tests scripts
@@ -59,6 +66,9 @@ commands =
 description = Generate HTML coverage report
 deps =
     {[testenv]deps}
+commands_pre =
+    python -m pip install awsiotsdk>=1.28.2
+    python -m pip install nwp500-python==7.4.9 --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \
            --cov-report=html \
@@ -69,6 +79,7 @@ commands =
 description = Validate HACS requirements
 deps =
 skip_install = True
+commands_pre =
 allowlist_externals =
     python
 commands =

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,3 @@
+version = 1
+revision = 3
+requires-python = ">=3.14"


### PR DESCRIPTION
## Summary

This PR contains two separate bodies of work:

### 1. Library upgrade: nwp500-python 7.4.9

Upgrades the core dependency from 7.4.8 to 7.4.9, which requires Python 3.14 and Home Assistant 2026.4.0+ (due to `aiohttp>=3.13.5` and `pydantic>=2.12.5` constraints). Tox configuration updated accordingly.

**Key library fixes in 7.4.9:**
- Timezone-naive datetime bug in token expiry
- Vacation mode sent wrong MQTT command
- Duplicate AWS IoT subscribe calls on reconnect
- Auth session leak on client construction failure

### 2. Full code review — bugs, services, blueprints, optimizations

#### Bugs fixed
- README version badge: 0.2.2 → 0.3.0
- Energy capacity sensors: corrected from `device_class=energy/state_class=total` to `energy_storage/measurement` (they represent current stored energy, not cumulative counters)
- Coordinator null guard before iterating `coordinator.data` keys (prevents crash during init)
- MQTT telemetry sensors: safe `.get()` with fallback to 0 instead of direct dict access
- `_connection_interruptions`: `list` → `deque(maxlen=20)` for thread safety
- `_tracked_mac_addresses`: `list` → `set` for O(1) membership checks
- Private `_last_reconnect_time` access → public `last_reconnect_time` property
- `asyncio.run_coroutine_threadsafe()` futures now have done-callbacks so exceptions are logged
- Local imports of `UnitOfTemperature` and temperature constants hoisted to module level
- `set_vacation_days` and `configure_tou_schedule` schemas now accept `entity_id`

#### 5 new services
All previously defined in `services.yaml`/`strings.json` but missing implementation:
- `enable_demand_response` / `disable_demand_response`: utility demand response control
- `reset_air_filter`: reset air filter maintenance timer
- `set_recirculation_mode`: 4-mode labeled select (Always On / Button / Schedule / Temperature)
- `trigger_recirculation`: manual hot-button trigger

#### 4 new automation blueprints
- **Solar Boost**: switch to High Demand on solar surplus, revert on drop
- **Away Mode**: vacation mode when all tracked persons are away
- **Leak Alert**: notify + optional power-off on moisture sensor trigger
- **Demand Response**: enable/disable DR via sensor signal or time window

#### Optimizations
- `_control_device()` helper in `water_heater.py` eliminates repeated boilerplate
- Cached `PatchedNavienMqttClient` class (defined once, not on every reconnect)
- Single top-level debug log in `send_command()` for all commands
- `time.time()` called once per request tracking block

---

**Tests:** 173 pass · **Coverage:** 80.37% · **mypy:** 0 errors