### PR TITLE
Adopt nwp500-python 8.1.0

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==8.0.0` - Core library for Navien device communication
+- `nwp500-python==8.1.0` - Core library for Navien device communication
 - `awsiotsdk>=1.29.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ This is a Home Assistant custom component that provides integration for Navien N
   - **GitHub Repository**: https://github.com/eman/nwp500-python
   - **Documentation**: https://nwp500-python.readthedocs.io/en/stable/
   - **PyPI Package**: https://pypi.org/project/nwp500-python/
-  - **Current Version**: 8.0.0 (see `custom_components/nwp500/manifest.json`)
+  - **Current Version**: 8.1.0 (see `custom_components/nwp500/manifest.json`)
   - **Note**: When instructions refer to "adopting a new library version" or "updating the library," they mean updating nwp500-python
 
 ### Home Assistant Integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Library Dependency: nwp500-python**: Upgraded from v8.0.0 to v8.1.0.
+  - **v8.1.0 (2026-05-16)**: Multiple bug fixes — see [release notes](https://github.com/eman/nwp500-python/releases/tag/v8.1.0)
+
 ## [0.15.0] - 2026-05-15
 
 ## [0.14.5] - 2026-05-13
@@ -331,6 +335,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Library Dependency: nwp500-python
 
 This section tracks changes in the nwp500-python library that this integration depends on.
+
+### v8.1.0 (2026-05-16)
+
+#### Fixed
+- **MQTT connection flapping after reconnect**: Old `MqttConnection` was never closed before creating a replacement, eventually causing two connections on the same client ID — AWS IoT would kick one off, triggering an infinite reconnect loop. Fixed by adding `MqttConnection.close()` and calling it in both `_active_reconnect()` and `_deep_reconnect()`.
+- **Thread-safety race in `ensure_device_info_cached`**: `future.done()` check and `future.set_result()` were running on the AWS SDK thread without synchronisation. Both operations now execute atomically inside a `call_soon_threadsafe` callback.
+- **ZeroDivisionError when `deep_reconnect_threshold` is 0**: Config validation now clamps the threshold to a minimum of 1.
+- **Reconnect counter never incremented**: `total_reconnect_attempts` always reported 0; counter is now incremented on each `on_connection_interrupted` event.
+- **`shortest_session_seconds` not JSON-serialisable**: `float('inf')` initial value replaced with `None` so diagnostics serialise correctly before any session completes.
+- **`wait_for()` future not bound to running loop**: Used `asyncio.get_running_loop().create_future()` instead of bare `asyncio.Future()`.
+- **Reservation temperature validation was US-only**: Validation now uses the active unit system — 35–65 °C in metric mode, 95–150 °F in US mode. Celsius users no longer receive spurious `ValueError` rejections.
+- **Malformed reservation data silently dropped**: `build_reservation_entry` now logs a warning when reservation hex data contains unexpected trailing bytes.
+- **Unknown `PeriodicRequestType` silently ignored**: Handler now logs an error and breaks instead of silently doing nothing.
+- **Memory leak in device info cache**: `get_all_cached()` now evicts expired entries from the cache dictionary instead of only filtering them from the return value.
+
+**Full release notes**: https://github.com/eman/nwp500-python/releases/tag/v8.1.0
 
 ### v7.3.4 (2026-01-27)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-05-16
+
 ### Changed
 - **Library Dependency: nwp500-python**: Upgraded from v8.0.0 to v8.1.0.
   - **v8.1.0 (2026-05-16)**: Multiple bug fixes — see [release notes](https://github.com/eman/nwp500-python/releases/tag/v8.1.0)
@@ -735,7 +737,8 @@ This section tracks changes in the nwp500-python library that this integration d
 - Device-based integration with proper device registry support
 - Integration with nwp500-python library v3.1.2
 
-[Unreleased]: https://github.com/eman/ha_nwp500/compare/v0.15.0...HEAD
+[Unreleased]: https://github.com/eman/ha_nwp500/compare/v0.15.1...HEAD
+[0.15.1]: https://github.com/eman/ha_nwp500/compare/v0.15.0...v0.15.1
 [0.15.0]: https://github.com/eman/ha_nwp500/compare/v0.14.5...v0.15.0
 [0.14.4]: https://github.com/eman/ha_nwp500/compare/v0.14.3...v0.14.4
 [0.14.3]: https://github.com/eman/ha_nwp500/compare/v0.14.2...v0.14.3

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ action:
 
 ## Library Version
 
-Uses **[nwp500-python v8.0.0](https://github.com/eman/nwp500-python/releases/tag/v8.0.0)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
+Uses **[nwp500-python v8.1.0](https://github.com/eman/nwp500-python/releases/tag/v8.1.0)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
 
 ## License
 

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -23,7 +23,6 @@ from homeassistant.exceptions import ConfigEntryNotReady, HomeAssistantError
 from homeassistant.helpers import config_validation as cv
 from homeassistant.helpers import device_registry as dr
 from homeassistant.helpers import entity_registry as er
-from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from .const import (
     DEFAULT_TEMPERATURE_C,

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -214,7 +214,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            'uv pip install "nwp500-python==8.0.0" awsiotsdk>=1.29.0'
+            'uv pip install "nwp500-python==8.1.0" awsiotsdk>=1.29.0'
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -587,7 +587,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                'uv pip install "nwp500-python==8.0.0" awsiotsdk>=1.29.0'
+                'uv pip install "nwp500-python==8.1.0" awsiotsdk>=1.29.0'
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -22,5 +22,5 @@
     "awsiotsdk>=1.29.0"
   ],
   "single_config_entry": true,
-  "version": "0.15.0"
+  "version": "0.15.1"
 }

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -18,7 +18,7 @@
     "custom_components.nwp500"
   ],
   "requirements": [
-    "nwp500-python==8.0.0",
+    "nwp500-python==8.1.0",
     "awsiotsdk>=1.29.0"
   ],
   "single_config_entry": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Usage: uv pip install -r requirements.txt
 # Core integration library
-nwp500-python==8.0.0
+nwp500-python==8.1.0
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.29.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-timeout>=2.1.0
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==8.0.0" --no-deps
+    python -m pip install "nwp500-python==8.1.0" --no-deps
 
 [testenv:py314]
 description = Run tests on Python 3.14
@@ -24,7 +24,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==8.0.0
+    nwp500-python==8.1.0
 commands_pre =
 
 [testenv:basedpyright]
@@ -32,7 +32,7 @@ description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==8.0.0
+    nwp500-python==8.1.0
 commands_pre =
 
 [testenv:ruff]
@@ -64,7 +64,7 @@ deps =
     {[testenv]deps}
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==8.0.0" --no-deps
+    python -m pip install "nwp500-python==8.1.0" --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \
            --cov-report=html \


### PR DESCRIPTION
## Summary

Upgrades the `nwp500-python` dependency from **8.0.0 → 8.1.0**.

## What's fixed in 8.1.0

### MQTT reliability
- **Connection flapping loop eliminated**: The old `MqttConnection` was never closed before creating a replacement during `_active_reconnect()`/`_deep_reconnect()`. The stale connection's built-in auto-reconnect would eventually succeed, creating two connections on the same AWS IoT client ID. The broker would kick one off, triggering another reconnect — an infinite loop. Fixed by adding `MqttConnection.close()` called unconditionally before replacement.
- **Thread-safety race in `ensure_device_info_cached`**: `future.done()` check and `future.set_result()` were running on the AWS SDK thread without synchronisation. Both operations now execute atomically inside a `call_soon_threadsafe` callback.

### Diagnostics
- **Reconnect counter never incremented**: `total_reconnect_attempts` always reported 0; now incremented on each `on_connection_interrupted` event.
- **`shortest_session_seconds` not JSON-serialisable**: `float('inf')` replaced with `None` so diagnostics serialise correctly before any session completes.

### Config / validation
- **ZeroDivisionError when `deep_reconnect_threshold` is 0**: Threshold now clamped to a minimum of 1.
- **Reservation temperature validation was US-only**: Validation now uses the active unit system — 35–65 °C in metric mode, 95–150 °F in US mode. Celsius users no longer receive spurious `ValueError` rejections for valid temperatures.
- **`wait_for()` future not bound to running loop**: Uses `asyncio.get_running_loop().create_future()` instead of bare `asyncio.Future()`.

### Data integrity
- **Malformed reservation data silently dropped**: `build_reservation_entry` now logs a warning for unexpected trailing bytes.
- **Unknown `PeriodicRequestType` silently ignored**: Handler now logs an error and breaks instead of silently doing nothing.
- **Memory leak in device info cache**: `get_all_cached()` now evicts expired entries from the cache dictionary instead of only filtering them from the return value.

## Files changed

| File | Change |
|------|--------|
| `manifest.json` | `nwp500-python==8.1.0` |
| `requirements.txt` | `nwp500-python==8.1.0` |
| `tox.ini` | All 4 occurrences updated |
| `coordinator.py` | Error message version string |
| `config_flow.py` | Error message version string |
| `README.md` | Library version badge |
| `CHANGELOG.md` | Unreleased entry + library history section |
| `.devcontainer/README.md` | Package version |
| `.github/copilot-instructions.md` | Current version updated |

## Testing

- ✅ 184 tests pass
- ✅ mypy: zero errors (env recreated with 8.1.0)
- ✅ Coverage: 82.18% (above 80% threshold)