### PR TITLE
chore: upgrade nwp500-python to 8.1.3

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==8.1.2` - Core library for Navien device communication
+- `nwp500-python==8.1.3` - Core library for Navien device communication
 - `awsiotsdk>=1.29.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ This is a Home Assistant custom component that provides integration for Navien N
   - **GitHub Repository**: https://github.com/eman/nwp500-python
   - **Documentation**: https://nwp500-python.readthedocs.io/en/stable/
   - **PyPI Package**: https://pypi.org/project/nwp500-python/
-  - **Current Version**: 8.1.1 (see `custom_components/nwp500/manifest.json`)
+  - **Current Version**: 8.1.3 (see `custom_components/nwp500/manifest.json`)
   - **Note**: When instructions refer to "adopting a new library version" or "updating the library," they mean updating nwp500-python
 
 ### Home Assistant Integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 ## [Unreleased]
 
+### Changed
+- **Library Dependency: nwp500-python**: Upgraded to 8.1.3. Fixes a
+  thread-safety bug in `on_connection_resumed` where `Task.cancel()` was called
+  directly from an AWS IoT SDK background thread. When the event loop was busy,
+  the cancellation could be silently dropped, leaving a stale
+  `_reconnect_with_backoff` task that would complete its sleep and tear down an
+  otherwise healthy connection — restarting the
+  disconnect → reconnect → `AWS_ERROR_MQTT_UNEXPECTED_HANGUP` cycle. See
+  [nwp500-python PR #89](https://github.com/eman/nwp500-python/pull/89).
+
 ## [0.15.4] - 2026-06-05
 
 ## [0.15.4] - 2026-06-05

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ action:
 
 ## Library Version
 
-Uses **[nwp500-python v8.1.2](https://github.com/eman/nwp500-python/releases/tag/v8.1.2)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
+Uses **[nwp500-python v8.1.3](https://github.com/eman/nwp500-python/releases/tag/v8.1.3)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
 
 ## License
 

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -214,7 +214,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            'uv pip install "nwp500-python==8.1.2" awsiotsdk>=1.29.0'
+            'uv pip install "nwp500-python==8.1.3" awsiotsdk>=1.29.0'
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -587,7 +587,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                'uv pip install "nwp500-python==8.1.2" awsiotsdk>=1.29.0'
+                'uv pip install "nwp500-python==8.1.3" awsiotsdk>=1.29.0'
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -18,7 +18,7 @@
     "custom_components.nwp500"
   ],
   "requirements": [
-    "nwp500-python==8.1.2",
+    "nwp500-python==8.1.3",
     "awsiotsdk>=1.29.0"
   ],
   "single_config_entry": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Usage: uv pip install -r requirements.txt
 # Core integration library
-nwp500-python==8.1.2
+nwp500-python==8.1.3
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.29.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-timeout>=2.1.0
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==8.1.2" --no-deps
+    python -m pip install "nwp500-python==8.1.3" --no-deps
 
 [testenv:py314]
 description = Run tests on Python 3.14
@@ -24,7 +24,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==8.1.2
+    nwp500-python==8.1.3
 commands_pre =
 
 [testenv:basedpyright]
@@ -32,7 +32,7 @@ description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==8.1.2
+    nwp500-python==8.1.3
 commands_pre =
 
 [testenv:ruff]
@@ -64,7 +64,7 @@ deps =
     {[testenv]deps}
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==8.1.2" --no-deps
+    python -m pip install "nwp500-python==8.1.3" --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \
            --cov-report=html \


### PR DESCRIPTION
Upgrades the `nwp500-python` library from 8.1.2 to 8.1.3.

## What changed in 8.1.3

Fixes a thread-safety bug where `asyncio.Task.cancel()` was called directly from an AWS IoT SDK background thread in `on_connection_resumed`. When the event loop was busy at the moment of cancellation (e.g. the sleeping task's 1-second timer callback had already been enqueued), the cancellation was silently dropped. The stale `_reconnect_with_backoff` task would then complete its sleep, call `_reconnect_func`, and tear down an otherwise healthy connection — restarting the entire disconnect → reconnect → `AWS_ERROR_MQTT_UNEXPECTED_HANGUP` cycle seen in production logs.

See [nwp500-python PR #89](https://github.com/eman/nwp500-python/pull/89) for the upstream fix.

## Files updated

| File | Change |
| ---- | ------ |
| `custom_components/nwp500/manifest.json` | `nwp500-python==8.1.3` |
| `requirements.txt` | `nwp500-python==8.1.3` |
| `tox.ini` | All 4 occurrences updated |
| `coordinator.py` | Error message install hint |
| `config_flow.py` | Error message install hint |
| `README.md` | Version badge link |
| `.devcontainer/README.md` | Package list |
| `.github/copilot-instructions.md` | Current Version field |
| `CHANGELOG.md` | Entry under `[Unreleased]` |