### PR TITLE
chore: Adopt nwp500-python v9.0.0

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==8.1.3` - Core library for Navien device communication
+- `nwp500-python==9.0.0` - Core library for Navien device communication
 - `awsiotsdk>=1.29.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@ This is a Home Assistant custom component that provides integration for Navien N
   - **GitHub Repository**: https://github.com/eman/nwp500-python
   - **Documentation**: https://nwp500-python.readthedocs.io/en/stable/
   - **PyPI Package**: https://pypi.org/project/nwp500-python/
-  - **Current Version**: 8.1.3 (see `custom_components/nwp500/manifest.json`)
+  - **Current Version**: 9.0.0 (see `custom_components/nwp500/manifest.json`)
   - **Note**: When instructions refer to "adopting a new library version" or "updating the library," they mean updating nwp500-python
 
 ### Home Assistant Integration

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## [Unreleased]
 
+### Changed
+- **Library Dependency: nwp500-python**: Upgraded to 9.0.0 (BREAKING). This
+  is a major version bump on the library side that trims its public API
+  surface and removes dead code; see the
+  [full release notes](https://github.com/eman/nwp500-python/releases/tag/v9.0.0)
+  for the complete list. Notable changes affecting this integration:
+  - Removed the never-raised `TokenExpiredError` exception. The coordinator's
+    authentication error handling no longer imports or catches it (the
+    remaining `TokenRefreshError`/`AuthenticationError` handling is
+    unaffected, since the library never actually raised this class).
+  - Numerous bug fixes relevant to this integration's stability: queued
+    control commands are now preserved in order and expire after a
+    configurable age instead of replaying stale commands after long
+    outages; MQTT message dispatch now runs on the event loop instead of
+    the AWS CRT network thread, fixing a potential
+    `RuntimeError: dictionary changed size during iteration` during
+    reconnects; the reconnection loop now survives all library errors
+    instead of dying silently on auth/token errors during an outage;
+    `error_detected` events are now emitted when the error code changes
+    between two non-zero values; and sub-zero Fahrenheit temperature
+    conversions are now rounded correctly.
+  - No changes were required to this integration's own use of
+    `build_reservation_entry`/`build_tou_period`, since it already imports
+    them from `nwp500.encoding` rather than the removed top-level
+    re-exports.
+
 ## [0.15.5] - 2026-06-15
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ action:
 
 ## Library Version
 
-Uses **[nwp500-python v8.1.3](https://github.com/eman/nwp500-python/releases/tag/v8.1.3)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
+Uses **[nwp500-python v9.0.0](https://github.com/eman/nwp500-python/releases/tag/v9.0.0)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
 
 ## License
 

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -214,7 +214,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            'uv pip install "nwp500-python==8.1.3" awsiotsdk>=1.29.0'
+            'uv pip install "nwp500-python==9.0.0" awsiotsdk>=1.29.0'
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -23,7 +23,6 @@ from nwp500.exceptions import (
     AuthenticationError,
     InvalidCredentialsError,
     MqttError,
-    TokenExpiredError,
     TokenRefreshError,
 )
 
@@ -587,7 +586,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                'uv pip install "nwp500-python==8.1.3" awsiotsdk>=1.29.0'
+                'uv pip install "nwp500-python==9.0.0" awsiotsdk>=1.29.0'
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"
@@ -764,7 +763,6 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             ) from err
         except (
             TokenRefreshError,
-            TokenExpiredError,
             AuthenticationError,
         ) as err:
             # Token or authentication errors - check if retriable

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -18,7 +18,7 @@
     "custom_components.nwp500"
   ],
   "requirements": [
-    "nwp500-python==8.1.3",
+    "nwp500-python==9.0.0",
     "awsiotsdk>=1.29.0"
   ],
   "single_config_entry": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Usage: uv pip install -r requirements.txt
 # Core integration library
-nwp500-python==8.1.3
+nwp500-python==9.0.0
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.29.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-timeout>=2.1.0
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==8.1.3" --no-deps
+    python -m pip install "nwp500-python==9.0.0" --no-deps
 
 [testenv:py314]
 description = Run tests on Python 3.14
@@ -24,7 +24,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==8.1.3
+    nwp500-python==9.0.0
 commands_pre =
 
 [testenv:basedpyright]
@@ -32,7 +32,7 @@ description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==8.1.3
+    nwp500-python==9.0.0
 commands_pre =
 
 [testenv:ruff]
@@ -64,7 +64,7 @@ deps =
     {[testenv]deps}
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==8.1.3" --no-deps
+    python -m pip install "nwp500-python==9.0.0" --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \
            --cov-report=html \


### PR DESCRIPTION
Upgrades the `nwp500-python` dependency from 8.1.3 to 9.0.0 (a breaking release upstream). See `CHANGELOG.md` for full details.

- Bumped version across `manifest.json`, `requirements.txt`, `tox.ini`, error messages, README, devcontainer docs, and copilot-instructions.
- Removed the never-raised `TokenExpiredError` import/except clause from `coordinator.py` (removed in v9.0.0; library never actually raised it).
- Confirmed `build_reservation_entry`/`build_tou_period` usage already imports from `nwp500.encoding` rather than the removed top-level re-exports, so no change needed there.

Verified with `tox -e mypy` (clean), `tox -e ruff` (clean), and `tox -e coverage` (187 tests passed, 82.12% coverage).

This PR is a prerequisite for the follow-up fix PRs addressing issues #84-#91 filed during the comprehensive repo review.