### PR TITLE
Adopt nwp500-python v9.2.0 and fix suggested area

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==9.0.0` - Core library for Navien device communication
+- `nwp500-python==9.2.0` - Core library for Navien device communication
 - `awsiotsdk>=1.29.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2024.1.0` - Home Assistant core
 - `mypy`, `pyright` - Type checkers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,13 +10,16 @@
   coordinator-level request timeouts on a connection that still appears up, and
   the integration now listens for the library's `reconnection_failed` event to
   trigger Home Assistant reauth when the internal loop stops permanently.
-- **AWS CRT clean-session warning workaround**: Kept the coordinator's temporary
-  asyncio exception-handler suppression for
-  `AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION`, but documented it as an
-  upstream-library workaround, linked the follow-up
-  [nwp500-python issue #97](https://github.com/eman/nwp500-python/issues/97),
-  and hardened handler install/restore so multiple config entries do not leave a
-  stale global loop handler behind on unload.
+- **AWS CRT clean-session warning workaround removed**: `nwp500-python` v9.2.0
+  fixes [issue #97](https://github.com/eman/nwp500-python/issues/97) upstream:
+  `_await_ack()` and the subscribe/unsubscribe acknowledgement waits now
+  attach a done callback whenever a shielded AWS CRT future is abandoned, so
+  the eventual result/exception is always retrieved and logged at debug level
+  by the library instead of leaking to asyncio's global exception handler.
+  The coordinator's temporary global asyncio exception-handler
+  install/restore machinery (`_nwp500_exception_handler`,
+  `_install_exception_handler`, `_restore_exception_handler`, and the shared
+  refcount globals) is no longer needed and has been removed.
 - **Recirculation Active binary sensor**: Removed the redundant "Recirculation
   Active" binary sensor (`recirculation_use`), which read the same
   `DeviceStatus.recirc_operation_busy` field as the existing "Recirculation
@@ -34,6 +37,25 @@
   `nwp500-python` 9.0.0 does not yet expose a matching public
   connect/open lifecycle method for the coordinator's longer-lived auth
   session.
+- **Library Dependency: nwp500-python**: Upgraded to
+  [9.2.0](https://github.com/eman/nwp500-python/releases/tag/v9.2.0). No
+  breaking changes affecting this integration. Notable changes:
+  - Fixes [issue #97](https://github.com/eman/nwp500-python/issues/97):
+    `_await_ack()` in `mqtt/connection.py` and the subscribe/unsubscribe
+    acknowledgement waits in `mqtt/subscriptions.py` now attach a done
+    callback whenever a shielded AWS CRT future is abandoned due to a
+    timeout or cancellation, so its eventual result/exception is always
+    retrieved and logged at debug level instead of leaking as an unhandled
+    "Future exception was never retrieved" asyncio warning. This obsoletes
+    this integration's own global asyncio exception-handler workaround,
+    which has been removed (see "Fixed" above).
+  - Internal refactors with no behavior change: CLI formatting stacks
+    merged behind a single Rich renderer, `mqtt/client.py` slimmed via
+    mixins, event-name constants de-duplicated between `events.py` and
+    `mqtt_events.py`, and `awscrt` types (e.g. `mqtt.QoS`) wrapped behind a
+    library-owned `nwp500.QoS` enum on public MQTT signatures. This
+    integration does not use `awscrt.mqtt.QoS` directly, so no code changes
+    were required.
 - **Library Dependency: nwp500-python**: Upgraded to 9.0.0 (BREAKING). This
   is a major version bump on the library side that trims its public API
   surface and removes dead code; see the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,12 +31,11 @@
   `from __future__ import annotations` imports from all
   `custom_components/nwp500/` modules now that this integration is
   Python 3.14-only, updated stale `nwp500-python` version-pinned comments
-  to reflect current v9.0.0 behavior, and replaced the auth-client
+  to reflect current library behavior, and replaced the auth-client
   shutdown dunder call with the library's public `close()` API. Initial
   auth setup still relies on `NavienAuthClient.__aenter__()` because
-  `nwp500-python` 9.0.0 does not yet expose a matching public
-  connect/open lifecycle method for the coordinator's longer-lived auth
-  session.
+  `nwp500-python` does not yet expose a matching public connect/open
+  lifecycle method for the coordinator's longer-lived auth session.
 - **Library Dependency: nwp500-python**: Upgraded to
   [9.2.0](https://github.com/eman/nwp500-python/releases/tag/v9.2.0). No
   breaking changes affecting this integration. Notable changes:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ action:
 
 ## Library Version
 
-Uses **[nwp500-python v9.0.0](https://github.com/eman/nwp500-python/releases/tag/v9.0.0)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
+Uses **[nwp500-python v9.2.0](https://github.com/eman/nwp500-python/releases/tag/v9.2.0)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
 
 ## License
 

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -212,7 +212,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            'uv pip install "nwp500-python==9.0.0" awsiotsdk>=1.29.0'
+            'uv pip install "nwp500-python==9.2.0" awsiotsdk>=1.29.0'
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -4,7 +4,6 @@ import asyncio
 import logging
 import time
 from collections import deque
-from collections.abc import Callable
 from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
@@ -45,34 +44,6 @@ if TYPE_CHECKING:
     )
 
 _LOGGER = logging.getLogger(__name__)
-
-LoopExceptionHandler = Callable[
-    [asyncio.AbstractEventLoop, dict[str, Any]], None
-]
-
-_SHARED_EXCEPTION_HANDLER_REFCOUNT = 0
-_SHARED_PREVIOUS_EXCEPTION_HANDLER: LoopExceptionHandler | None = None
-
-
-def _nwp500_exception_handler(
-    loop: asyncio.AbstractEventLoop, context: dict[str, Any]
-) -> None:
-    """Suppress the known benign AWS CRT clean-session cancellation warning."""
-    exception = context.get("exception")
-
-    if isinstance(exception, AwsCrtError):
-        error_name = get_aws_error_name(exception)
-        if error_name == "AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION":
-            _LOGGER.debug(
-                "Suppressed benign AWS CRT error during MQTT reconnection: %s",
-                exception,
-            )
-            return
-
-    if _SHARED_PREVIOUS_EXCEPTION_HANDLER:
-        _SHARED_PREVIOUS_EXCEPTION_HANDLER(loop, context)
-    else:
-        loop.default_exception_handler(context)
 
 
 class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
@@ -139,76 +110,6 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             name=DOMAIN,
             update_interval=timedelta(seconds=scan_interval),
         )
-
-        self._exception_handler_installed = False
-        # Temporary library workaround; remove after nwp500-python fixes issue #97.
-        self._install_exception_handler()
-
-    def _install_exception_handler(self) -> None:
-        """Install custom exception handler to suppress benign AWS CRT errors.
-
-        AWS IoT SDK creates internal futures during MQTT operations. When a clean
-        session reconnection occurs, pending operations are cancelled with
-        AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION. These exceptions can complete
-        after our await/timeout handling, causing "Future exception was never
-        retrieved" errors in Home Assistant logs.
-
-        This is still needed until the library consumes its own internal MQTT
-        acknowledgement futures instead of leaking them to asyncio's global
-        exception handler. Tracked upstream: https://github.com/eman/nwp500-python/issues/97
-        """
-        global \
-            _SHARED_EXCEPTION_HANDLER_REFCOUNT, \
-            _SHARED_PREVIOUS_EXCEPTION_HANDLER
-
-        loop = self.hass.loop
-        if loop.get_exception_handler() is _nwp500_exception_handler:
-            _SHARED_EXCEPTION_HANDLER_REFCOUNT += 1
-            self._exception_handler_installed = True
-            return
-
-        if _SHARED_EXCEPTION_HANDLER_REFCOUNT > 0:
-            # Another active coordinator instance already installed the
-            # handler and is tracked in the shared refcount, but something
-            # external replaced the loop's exception handler afterward.
-            # Re-install ours without resetting the refcount, so restore()
-            # still waits for every active instance to unload before
-            # restoring the original handler.
-            _LOGGER.warning(
-                "NWP500 asyncio exception handler was replaced externally; "
-                "reinstalling it without resetting the shared refcount"
-            )
-            loop.set_exception_handler(_nwp500_exception_handler)
-            _SHARED_EXCEPTION_HANDLER_REFCOUNT += 1
-            self._exception_handler_installed = True
-            return
-
-        _SHARED_PREVIOUS_EXCEPTION_HANDLER = loop.get_exception_handler()
-        loop.set_exception_handler(_nwp500_exception_handler)
-        _SHARED_EXCEPTION_HANDLER_REFCOUNT = 1
-        self._exception_handler_installed = True
-
-    def _restore_exception_handler(self) -> None:
-        """Restore the previous loop exception handler when the last entry unloads."""
-        global \
-            _SHARED_EXCEPTION_HANDLER_REFCOUNT, \
-            _SHARED_PREVIOUS_EXCEPTION_HANDLER
-
-        if not self._exception_handler_installed:
-            return
-
-        self._exception_handler_installed = False
-        if _SHARED_EXCEPTION_HANDLER_REFCOUNT > 0:
-            _SHARED_EXCEPTION_HANDLER_REFCOUNT -= 1
-
-        if _SHARED_EXCEPTION_HANDLER_REFCOUNT != 0:
-            return
-
-        loop = self.hass.loop
-        if loop.get_exception_handler() is _nwp500_exception_handler:
-            loop.set_exception_handler(_SHARED_PREVIOUS_EXCEPTION_HANDLER)
-
-        _SHARED_PREVIOUS_EXCEPTION_HANDLER = None
 
     def _update_device_cache(self) -> None:
         """Update the devices-by-MAC lookup cache for O(1) access.
@@ -638,7 +539,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                'uv pip install "nwp500-python==9.0.0" awsiotsdk>=1.29.0'
+                'uv pip install "nwp500-python==9.2.0" awsiotsdk>=1.29.0'
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"
@@ -1279,8 +1180,6 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
             self.auth_client = None
 
         self.api_client = None
-
-        self._restore_exception_handler()
 
         # Clear device features cache to prevent memory leaks
         self.device_features.clear()

--- a/custom_components/nwp500/entity.py
+++ b/custom_components/nwp500/entity.py
@@ -210,12 +210,6 @@ class NWP500Entity(CoordinatorEntity[NWP500DataUpdateCoordinator]):
             f"https://app.naviensmartcontrol.com/device/{self.mac_address}"
         )
 
-        # Suggested area from location if available
-        if hasattr(self.device, "location") and self.device.location:
-            location = self.device.location
-            if location.city:
-                suggested_area = location.city
-
         # Create DeviceInfo
         return DeviceInfo(
             identifiers={(DOMAIN, self.mac_address)},

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -18,7 +18,7 @@
     "custom_components.nwp500"
   ],
   "requirements": [
-    "nwp500-python==9.0.0",
+    "nwp500-python==9.2.0",
     "awsiotsdk>=1.29.0"
   ],
   "single_config_entry": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Usage: uv pip install -r requirements.txt
 # Core integration library
-nwp500-python==9.0.0
+nwp500-python==9.2.0
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.29.0

--- a/tests/unit/test_coordinator.py
+++ b/tests/unit/test_coordinator.py
@@ -4,21 +4,9 @@ import time
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from awscrt.exceptions import AwsCrtError
 from homeassistant.helpers.update_coordinator import UpdateFailed
 
-from custom_components.nwp500 import coordinator as coordinator_module
 from custom_components.nwp500.coordinator import NWP500DataUpdateCoordinator
-
-
-@pytest.fixture(autouse=True)
-def reset_shared_exception_handler_state():
-    """Reset module-level exception handler state between tests."""
-    coordinator_module._SHARED_EXCEPTION_HANDLER_REFCOUNT = 0
-    coordinator_module._SHARED_PREVIOUS_EXCEPTION_HANDLER = None
-    yield
-    coordinator_module._SHARED_EXCEPTION_HANDLER_REFCOUNT = 0
-    coordinator_module._SHARED_PREVIOUS_EXCEPTION_HANDLER = None
 
 
 @pytest.fixture
@@ -33,13 +21,8 @@ def mock_entry():
 @pytest.fixture
 def coordinator(mock_hass, mock_entry):
     """Create NWP500DataUpdateCoordinator instance."""
-    with (
-        patch(
-            "custom_components.nwp500.coordinator.DataUpdateCoordinator.__init__"
-        ),
-        patch(
-            "custom_components.nwp500.coordinator.NWP500DataUpdateCoordinator._install_exception_handler"
-        ),
+    with patch(
+        "custom_components.nwp500.coordinator.DataUpdateCoordinator.__init__"
     ):
         coordinator = NWP500DataUpdateCoordinator(mock_hass, mock_entry)
         coordinator.hass = mock_hass
@@ -56,97 +39,6 @@ def _make_disconnected_mqtt_manager(
     mgr.last_reconnect_time = time.time() + last_reconnect_offset
     mgr.force_reconnect = AsyncMock(return_value=True)
     return mgr
-
-
-def _make_loop_with_handler(
-    handler: object | None,
-) -> tuple[MagicMock, list[object | None]]:
-    """Create a mock loop that tracks exception handler changes."""
-    current_handler = handler
-    handler_updates: list[object | None] = []
-    loop = MagicMock()
-    loop.default_exception_handler = MagicMock()
-
-    def get_exception_handler() -> object | None:
-        return current_handler
-
-    def set_exception_handler(new_handler: object | None) -> None:
-        nonlocal current_handler
-        current_handler = new_handler
-        handler_updates.append(new_handler)
-
-    loop.get_exception_handler.side_effect = get_exception_handler
-    loop.set_exception_handler.side_effect = set_exception_handler
-    return loop, handler_updates
-
-
-def _mock_data_update_coordinator_init(
-    self, hass, logger, name, update_interval
-):
-    """Stub DataUpdateCoordinator.__init__ for unit tests."""
-    self.hass = hass
-
-
-@pytest.mark.asyncio
-async def test_exception_handler_suppresses_clean_session_error(
-    mock_hass, mock_entry
-):
-    """The workaround suppresses the known benign AWS CRT clean-session error."""
-    original_handler = MagicMock()
-    loop, _ = _make_loop_with_handler(original_handler)
-    mock_hass.loop = loop
-
-    with patch(
-        "custom_components.nwp500.coordinator.DataUpdateCoordinator.__init__",
-        autospec=True,
-        side_effect=_mock_data_update_coordinator_init,
-    ):
-        coordinator = NWP500DataUpdateCoordinator(mock_hass, mock_entry)
-
-    error = AwsCrtError(
-        code=0,
-        name="AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION",
-        message="Clean session",
-    )
-    error.name = "AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION"
-    handler = mock_hass.loop.get_exception_handler()
-
-    handler(mock_hass.loop, {"exception": error})
-
-    original_handler.assert_not_called()
-    mock_hass.loop.default_exception_handler.assert_not_called()
-
-    await coordinator.async_shutdown()
-
-
-@pytest.mark.asyncio
-async def test_exception_handler_restores_previous_handler_after_last_unload(
-    mock_hass, mock_entry
-):
-    """The shared workaround restores the prior handler only after the last unload."""
-    original_handler = MagicMock()
-    loop, handler_updates = _make_loop_with_handler(original_handler)
-    mock_hass.loop = loop
-
-    with patch(
-        "custom_components.nwp500.coordinator.DataUpdateCoordinator.__init__",
-        autospec=True,
-        side_effect=_mock_data_update_coordinator_init,
-    ):
-        coordinator_one = NWP500DataUpdateCoordinator(mock_hass, mock_entry)
-        coordinator_two = NWP500DataUpdateCoordinator(mock_hass, mock_entry)
-
-    assert handler_updates == [coordinator_module._nwp500_exception_handler]
-
-    await coordinator_one.async_shutdown()
-    assert (
-        mock_hass.loop.get_exception_handler()
-        is coordinator_module._nwp500_exception_handler
-    )
-
-    await coordinator_two.async_shutdown()
-    assert handler_updates[-1] is original_handler
-    assert mock_hass.loop.get_exception_handler() is original_handler
 
 
 def test_on_device_status_update_schedules_loop_task(coordinator, mock_hass):

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-timeout>=2.1.0
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==9.0.0" --no-deps
+    python -m pip install "nwp500-python==9.2.0" --no-deps
 
 [testenv:py314]
 description = Run tests on Python 3.14
@@ -24,7 +24,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==9.0.0
+    nwp500-python==9.2.0
 commands_pre =
 
 [testenv:basedpyright]
@@ -32,7 +32,7 @@ description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
     homeassistant>=2026.4.0
-    nwp500-python==9.0.0
+    nwp500-python==9.2.0
 commands_pre =
 
 [testenv:ruff]
@@ -64,7 +64,7 @@ deps =
     {[testenv]deps}
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==9.0.0" --no-deps
+    python -m pip install "nwp500-python==9.2.0" --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \
            --cov-report=html \


### PR DESCRIPTION
## Summary
- Adopt nwp500-python v9.2.0 (see CHANGELOG.md for details)
- Remove city-based `suggested_area` override in `entity.py` — the device's Navien account city has no relation to the user's actual Home Assistant room/area, so entities now default to "Utility Room" instead.

## Testing
- `tox -e mypy` passes with zero errors