### PR TITLE
fix: Raise declared Home Assistant floor to 2026.3.0

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # Development container for Navien NWP500 Home Assistant Integration
-FROM mcr.microsoft.com/devcontainers/python:3.13
+FROM mcr.microsoft.com/devcontainers/python:3.14
 
 # Set environment variables
 ENV PYTHONUNBUFFERED=1 \

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -18,7 +18,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 ## What's Included
 
 ### Base Environment
-- **Python 3.12**: Matches the project's Python version requirement
+- **Python 3.14**: Matches the project's Python version requirement
 - **Git**: For version control
 - **Docker-in-Docker**: Enables running docker-compose for Home Assistant testing
 
@@ -61,7 +61,7 @@ tox -e coverage
 
 # Run type checking
 tox -e mypy
-tox -e pyright
+tox -e basedpyright
 ```
 
 ### Type Checking
@@ -69,8 +69,8 @@ tox -e pyright
 # MyPy (enforced before commits)
 mypy --config-file mypy.ini custom_components/nwp500
 
-# Pyright (alternative type checker)
-pyright custom_components/nwp500
+# basedpyright (alternative type checker)
+basedpyright custom_components/nwp500
 ```
 
 ### Running Home Assistant
@@ -101,7 +101,7 @@ Home Assistant will be available at `http://localhost:8123`
 - Sets up post-creation commands
 
 ### Dockerfile
-- Based on Microsoft's official Python 3.12 devcontainer image
+- Based on Microsoft's official Python 3.14 devcontainer image
 - Installs system dependencies
 - Pre-installs all Python requirements
 - Sets up development tools

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -26,8 +26,8 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 All packages from `requirements.txt` are pre-installed:
 - `nwp500-python==9.2.0` - Core library for Navien device communication
 - `awsiotsdk>=1.29.0` - AWS IoT SDK for MQTT
-- `homeassistant>=2024.1.0` - Home Assistant core
-- `mypy`, `pyright` - Type checkers
+- `homeassistant>=2026.3.0` - Home Assistant core
+- `mypy`, `basedpyright` - Type checkers
 - `pytest` and related testing tools
 - `tox` - Test automation
 

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -24,10 +24,9 @@ The CI pipeline is defined in `.github/workflows/ci.yml` and runs automatically 
 - **Command**: `tox -e pyright`
 
 ### 3. Tests
-- **Purpose**: Run unit tests across Python versions
-- **Python Versions**: 3.12 and 3.13
-- **Command**: `tox -e py312` / `tox -e py313`
-- **Note**: Python 3.12 allowed to fail (optional)
+- **Purpose**: Run unit tests
+- **Python Versions**: 3.14 (the integration uses Python 3.14-only syntax)
+- **Command**: `tox -e py314`
 
 ### 4. Coverage
 - **Purpose**: Ensure test coverage meets requirements
@@ -66,7 +65,7 @@ tox
 # Or run individual checks
 tox -e mypy      # Type checking with mypy
 tox -e pyright   # Type checking with pyright
-tox -e py313     # Unit tests on Python 3.13
+tox -e py314     # Unit tests on Python 3.14
 tox -e coverage  # Tests with coverage validation
 ```
 
@@ -92,7 +91,7 @@ If coverage is below 80%:
 
 If unit tests fail:
 1. Review the test output in the CI log
-2. Run failing tests locally: `tox -e py313 -- tests/path/to/test.py`
+2. Run failing tests locally: `tox -e py314 -- tests/path/to/test.py`
 3. Fix the code or tests
 4. Verify all tests pass before pushing
 
@@ -116,7 +115,7 @@ This is configured in `.coveragerc`.
 All PRs must pass CI checks before merging:
 - mypy type checking
 - pyright type checking
-- Unit tests (Python 3.13)
+- Unit tests (Python 3.14)
 - Coverage ≥80%
 
 The "All Checks Passed" job provides a single status check that must be green.

--- a/.github/CI.md
+++ b/.github/CI.md
@@ -11,34 +11,50 @@ The CI pipeline is defined in `.github/workflows/ci.yml` and runs automatically 
 
 ## CI Jobs
 
-### 1. Type Check (mypy)
+All jobs run on Python 3.14 unless noted — the integration uses Python
+3.14-only syntax and will not import on older interpreters.
+
+### 1. Lint (ruff)
+- **Purpose**: Linting and formatting checks
+- **Command**: `tox -e ruff`
+
+### 2. Hassfest Validation
+- **Purpose**: Official Home Assistant manifest/integration validation
+- **Runs**: `home-assistant/actions/hassfest` (no local tox env)
+
+### 3. Type Check (mypy)
 - **Purpose**: Validate type hints using mypy
 - **Requirement**: Must pass with 0 errors
-- **Python Version**: 3.12
 - **Command**: `tox -e mypy`
 
-### 2. Type Check (pyright)
-- **Purpose**: Validate type hints using pyright
-- **Requirement**: Must pass with 0 errors (warnings acceptable)
-- **Python Version**: 3.12
-- **Command**: `tox -e pyright`
+### 4. Check Deprecated APIs
+- **Purpose**: Flag deprecated Home Assistant API usage
+- **Python Version**: 3.13 (the script scans source text and does not import it)
+- **Command**: `python3 scripts/check_deprecated_apis.py`
 
-### 3. Tests
+### 5. Type Check (basedpyright)
+- **Purpose**: Validate type hints using basedpyright
+- **Requirement**: Must pass with 0 errors (warnings acceptable)
+- **Command**: `tox -e basedpyright`
+
+### 6. Tests
 - **Purpose**: Run unit tests
-- **Python Versions**: 3.14 (the integration uses Python 3.14-only syntax)
 - **Command**: `tox -e py314`
 
-### 4. Coverage
+### 7. Test Coverage
 - **Purpose**: Ensure test coverage meets requirements
 - **Requirement**: ≥80% overall coverage
-- **Python Version**: 3.13
 - **Command**: `tox -e coverage`
 - **Artifacts**:
   - Coverage report uploaded to Codecov
   - HTML coverage report saved as artifact (30-day retention)
   - XML coverage report for external tools
 
-### 5. All Checks Passed
+### 8. HACS Validation
+- **Purpose**: Validate the repository against HACS requirements
+- **Defined in**: `.github/workflows/hacs.yaml`
+
+### 9. All Checks Passed
 - **Purpose**: Summary job that requires all checks to pass
 - **Fails if**: Any of the above jobs fail
 
@@ -64,7 +80,7 @@ tox
 
 # Or run individual checks
 tox -e mypy      # Type checking with mypy
-tox -e pyright   # Type checking with pyright
+tox -e basedpyright  # Type checking with basedpyright
 tox -e py314     # Unit tests on Python 3.14
 tox -e coverage  # Tests with coverage validation
 ```
@@ -73,10 +89,10 @@ tox -e coverage  # Tests with coverage validation
 
 ### Type Checking Failures
 
-If mypy or pyright fails:
+If mypy or basedpyright fails:
 1. Review the error messages in the CI log
 2. Fix type hints in the reported files
-3. Run `tox -e mypy` and `tox -e pyright` locally to verify
+3. Run `tox -e mypy` and `tox -e basedpyright` locally to verify
 4. Commit and push the fixes
 
 ### Coverage Failures
@@ -114,7 +130,7 @@ This is configured in `.coveragerc`.
 
 All PRs must pass CI checks before merging:
 - mypy type checking
-- pyright type checking
+- basedpyright type checking
 - Unit tests (Python 3.14)
 - Coverage ≥80%
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,16 @@
   docstring, the `homeassistant>=2025.1.0` development pin, and the stale
   Python 3.12/3.13 references in the development and CI docs. Raised in
   [hacs/default#6988](https://github.com/hacs/default/pull/6988).
+- **Dev container could not run the integration**: `.devcontainer/Dockerfile`
+  built on `python:3.13`, so the "Recommended" development path could not
+  import the integration's Python 3.14-only syntax at all. Bumped to
+  `python:3.14` and corrected the dev container's stale
+  `homeassistant>=2024.1.0` package list. Also aligned the `homeassistant`
+  floor in the mypy/basedpyright tox environments with the declared HACS
+  minimum, and corrected the CI/development docs, which described a
+  `tox -e pyright` environment that does not exist (the env and CI job are
+  both `basedpyright`) and listed a Python 3.12/3.13 job matrix that no longer
+  matches `.github/workflows/ci.yml`.
 
 ## [0.16.2] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@
   blocks as ```` ```text ```` so the formatter leaves the alignment alone, and
   raises the floor to `ruff>=0.16.0` so a local run cannot silently pass with an
   older ruff than CI uses.
+- **Declared Home Assistant floor raised to 2026.3.0**: `hacs.json` declared
+  `2025.1.0`, but the integration ships PEP 758 parenthesis-less multi-type
+  `except` clauses (e.g. `except CannotConnect, InvalidAuth:`) in nine modules.
+  That syntax is Python 3.14 only, which means Home Assistant 2026.3 or newer;
+  on anything older every one of those modules fails to import with a
+  `SyntaxError`, so users on 2025.x through 2026.2 would install a broken
+  integration from HACS. Raises the declared floor to `2026.3.0` and corrects
+  the contradictory "Requires Home Assistant 2025.1+ (Python 3.14)" module
+  docstring, the `homeassistant>=2025.1.0` development pin, and the stale
+  Python 3.12/3.13 references in the development and CI docs. Raised in
+  [hacs/default#6988](https://github.com/hacs/default/pull/6988).
 
 ## [0.16.2] - 2026-07-14
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -121,12 +121,12 @@ tox -e mypy
 
 ### Pyright
 ```bash
-tox -e pyright
+tox -e basedpyright
 ```
 - Fast, IDE-integrated type checker
 - Configuration in `pyrightconfig.json`
 - Set to `basic` mode for balanced strictness
-- Both mypy and pyright must pass in CI
+- Both mypy and basedpyright must pass in CI
 
 ### Type Hints
 - Use full type hints throughout (from `__future__ import annotations`)
@@ -153,7 +153,7 @@ python3 scripts/check_deprecated_apis.py
 2. `hassfest` - Official Home Assistant validation
 3. `deprecated-apis` - No deprecated HA APIs
 4. `mypy` - Type check with mypy (Python 3.14)
-5. `pyright` - Type check with pyright (Python 3.14)
+5. `basedpyright` - Type check with basedpyright (Python 3.14)
 6. `tests` - Tests on Python 3.14
 7. `coverage` - 80%+ coverage enforced
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -42,8 +42,8 @@ Device Control: HA Command → MQTT Message → Device Response → Status Updat
 ## Setting Up Development
 
 ### Prerequisites
-- Python 3.13+
-- Home Assistant 2025.1.0+
+- Python 3.14+
+- Home Assistant 2026.3.0+
 - Virtual environment recommended
 
 ### Environment Setup
@@ -68,7 +68,7 @@ uv pip install -r requirements.txt
 tox
 
 # Specific environments
-tox -e py313            # Test on Python 3.13
+tox -e py314            # Test on Python 3.14
 tox -e coverage         # Test with coverage (requires 80%+)
 tox -e mypy             # Type check with mypy
 tox -e basedpyright     # Type check with basedpyright
@@ -152,9 +152,9 @@ python3 scripts/check_deprecated_apis.py
 1. `lint` - Automated linting and formatting (ruff)
 2. `hassfest` - Official Home Assistant validation
 3. `deprecated-apis` - No deprecated HA APIs
-4. `mypy` - Type check with mypy (Python 3.13)
-5. `pyright` - Type check with pyright (Python 3.13)
-6. `tests` - Tests on Python 3.13 + 3.14
+4. `mypy` - Type check with mypy (Python 3.14)
+5. `pyright` - Type check with pyright (Python 3.14)
+6. `tests` - Tests on Python 3.14
 7. `coverage` - 80%+ coverage enforced
 
 ## Releasing

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![CI](https://github.com/eman/ha_nwp500/actions/workflows/ci.yml/badge.svg)](https://github.com/eman/ha_nwp500/actions/workflows/ci.yml)
 [![Coverage](https://img.shields.io/badge/coverage-80%25-yellowgreen)](#)
 [![HACS](https://img.shields.io/badge/HACS-Custom-orange.svg)](https://github.com/hacs/integration)
-[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.4.0%2B-41BDF5)](https://www.home-assistant.io/)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-2026.3.0%2B-41BDF5)](https://www.home-assistant.io/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -1,6 +1,6 @@
 """The Navien NWP500 integration.
 
-Requires Home Assistant 2025.1+ (Python 3.14).
+Requires Home Assistant 2026.3+ (Python 3.14).
 """
 
 import logging

--- a/hacs.json
+++ b/hacs.json
@@ -2,5 +2,5 @@
   "name": "Navien NWP500",
   "content_in_root": false,
   "render_readme": true,
-  "homeassistant": "2025.1.0"
+  "homeassistant": "2026.3.0"
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,7 +25,7 @@ pytest-homeassistant-custom-component>=0.13.0
 pytest-timeout>=2.1.0
 
 # Home Assistant
-homeassistant>=2025.1.0
+homeassistant>=2026.3.0
 
 # Test automation
 tox>=4.0.0

--- a/tox.ini
+++ b/tox.ini
@@ -23,7 +23,7 @@ basepython = python3.14
 description = Run mypy type checking
 deps =
     mypy>=1.0.0
-    homeassistant>=2026.4.0
+    homeassistant>=2026.3.0
     nwp500-python==9.2.0
 commands_pre =
 
@@ -31,7 +31,7 @@ commands_pre =
 description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
-    homeassistant>=2026.4.0
+    homeassistant>=2026.3.0
     nwp500-python==9.2.0
 commands_pre =
 


### PR DESCRIPTION
Addresses the HACS review feedback on [hacs/default#6988](https://github.com/hacs/default/pull/6988#pullrequestreview-4818273502).

## Problem

`hacs.json` declared `"homeassistant": "2025.1.0"`, but the integration ships PEP 758 parenthesis-less multi-type `except` clauses in nine modules, for example `config_flow.py:246`:

```python
except CannotConnect, InvalidAuth:
```

That syntax is Python 3.14 only, which means Home Assistant 2026.3 or newer. On anything older, every one of those modules fails at import with a `SyntaxError`:

```
custom_components/nwp500/{binary_sensor,config_flow,const,coordinator,
                          entity,number,sensor,switch,water_heater}.py
SyntaxError: multiple exception types must be parenthesized
```

So users on 2025.x through 2026.2 would install this from HACS and get a broken setup. It went unnoticed because `ruff` is configured with `target-version = "py314"` (which is what rewrote the parenthesized form in 6a356c9) and the entire tox/CI matrix is Python 3.14.

## Fix

Per the review, raise the declared floor rather than change the code. Also corrects the four declarations that contradicted it:

| File | Before | After |
|---|---|---|
| `hacs.json` | `"homeassistant": "2025.1.0"` | `"2026.3.0"` |
| `__init__.py` docstring | `Requires Home Assistant 2025.1+ (Python 3.14)` | `2026.3+ (Python 3.14)` |
| `requirements.txt` | `homeassistant>=2025.1.0` | `>=2026.3.0` |
| `DEVELOPMENT.md` | `Python 3.13+` / `HA 2025.1.0+`, `tox -e py313` | `3.14+` / `2026.3.0+`, `tox -e py314` |
| `.github/CI.md` | "Python Versions: 3.12 and 3.13" | `3.14` |

The `tox -e py313` / `py312` references were doubly wrong: `tox.ini` has `envlist = py314,...`, so those environments don't exist, and CI's test matrix is `["3.14"]`.

## Verification

- `validate_hacs.py` passes
- 204 tests pass, ruff check + format clean

## Note

The `deprecated-apis` CI job still runs on Python 3.13 (`ci.yml:83`). `scripts/check_deprecated_apis.py` scans by regex rather than `ast.parse`, so it passes on 3.13 — left alone rather than churning a working job, but bumping it to 3.14 would remove the last 3.13 reference in CI.

Frenck asked for a new release and a re-request of review once this lands, so this still needs a version bump on top.