### PR TITLE
chore: Adopt nwp500-python v9.2.1

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==9.2.0` - Core library for Navien device communication
+- `nwp500-python==9.2.1` - Core library for Navien device communication
 - `awsiotsdk>=1.29.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2026.3.0` - Home Assistant core
 - `mypy`, `basedpyright` - Type checkers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,36 @@
   both `basedpyright`) and listed a Python 3.12/3.13 job matrix that no longer
   matches `.github/workflows/ci.yml`.
 
+### Changed
+- **Library Dependency: nwp500-python**: Upgraded to
+  [9.2.1](https://github.com/eman/nwp500-python/releases/tag/v9.2.1). No
+  breaking changes affecting this integration, and no code changes were
+  required. Notable changes:
+  - Demand response commands are now gated on the `dr_setting_use` capability
+    flag ([issue #114](https://github.com/eman/nwp500-python/issues/114)).
+    The `nwp500.enable_demand_response` / `nwp500.disable_demand_response`
+    services will now fail with "Failed to enable/disable demand response" on
+    devices that do not report DR support, instead of silently dispatching a
+    command the device ignores. This matches the behavior the integration
+    already had for every other capability-gated command (`set_power`,
+    `set_dhw_mode`, `set_tou_enabled`, recirculation), so no new handling was
+    needed.
+  - `set_freeze_protection_temperature` now validates against the device's
+    reported `freeze_protection_temp_min`/`freeze_protection_temp_max` and is
+    gated on the `freeze_protection_use` capability
+    ([issue #112](https://github.com/eman/nwp500-python/issues/112)). This
+    integration does not call that command, so there is no impact.
+  - Adds opt-in `update_reservations_confirmed()` /
+    `configure_tou_schedule_confirmed()` helpers that await the device's
+    `rsv/rd`/`tou/rd` echo and return the schedule the device actually holds,
+    plus `canonical()` comparison helpers
+    ([issue #111](https://github.com/eman/nwp500-python/issues/111)). The
+    `update_reservations` and `configure_tou_schedule` services still use the
+    fire-and-forget variants and report success once the write is published;
+    adopting the confirmed variants is tracked separately.
+  - Documentation fix to the `decode_reservation_hex` docstring
+    ([issue #113](https://github.com/eman/nwp500-python/issues/113)).
+
 ## [0.16.2] - 2026-07-14
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ action:
 
 ## Library Version
 
-Uses **[nwp500-python v9.2.0](https://github.com/eman/nwp500-python/releases/tag/v9.2.0)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
+Uses **[nwp500-python v9.2.1](https://github.com/eman/nwp500-python/releases/tag/v9.2.1)**. See [CHANGELOG.md](CHANGELOG.md#library-dependency-nwp500-python) for version history.
 
 ## License
 

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -212,7 +212,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            'uv pip install "nwp500-python==9.2.0" awsiotsdk>=1.29.0'
+            'uv pip install "nwp500-python==9.2.1" awsiotsdk>=1.29.0'
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -535,7 +535,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                'uv pip install "nwp500-python==9.2.0" awsiotsdk>=1.29.0'
+                'uv pip install "nwp500-python==9.2.1" awsiotsdk>=1.29.0'
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -18,7 +18,7 @@
     "custom_components.nwp500"
   ],
   "requirements": [
-    "nwp500-python==9.2.0",
+    "nwp500-python==9.2.1",
     "awsiotsdk>=1.29.0"
   ],
   "single_config_entry": true,

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Usage: uv pip install -r requirements.txt
 # Core integration library
-nwp500-python==9.2.0
+nwp500-python==9.2.1
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk>=1.29.0

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-timeout>=2.1.0
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==9.2.0" --no-deps
+    python -m pip install "nwp500-python==9.2.1" --no-deps
 
 [testenv:py314]
 description = Run tests on Python 3.14
@@ -24,7 +24,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2026.3.0
-    nwp500-python==9.2.0
+    nwp500-python==9.2.1
 commands_pre =
 
 [testenv:basedpyright]
@@ -32,7 +32,7 @@ description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
     homeassistant>=2026.3.0
-    nwp500-python==9.2.0
+    nwp500-python==9.2.1
 commands_pre =
 
 [testenv:ruff]
@@ -64,7 +64,7 @@ deps =
     {[testenv]deps}
 commands_pre =
     python -m pip install awsiotsdk>=1.29.0
-    python -m pip install "nwp500-python==9.2.0" --no-deps
+    python -m pip install "nwp500-python==9.2.1" --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \
            --cov-report=html \


### PR DESCRIPTION
Bumps the pin to [v9.2.1](https://github.com/eman/nwp500-python/releases/tag/v9.2.1) in `manifest.json`, `requirements.txt`, `tox.ini` and the `config_flow` install hint. **No integration code changes were required.**

## Review of each change in the release

### Demand response gated on `dr_setting_use` ([#114](https://github.com/eman/nwp500-python/issues/114))

The only change that touches this integration. `enable_demand_response` / `disable_demand_response` now raise `DeviceCapabilityError` on devices that don't report DR support, and this integration calls both from its services.

No new handling was needed. `mqtt_manager.send_command()` already funnels every exception through its generic error path, and `set_power`, `set_dhw_mode`, `set_tou_enabled` and the recirculation commands were *already* capability-gated the same way upstream — DR was the one gap, and it now joins the existing pattern.

Net effect: the `nwp500.enable_demand_response` / `nwp500.disable_demand_response` services now fail with `Failed to enable/disable demand response` on unsupported devices instead of silently dispatching a command the device ignores. An improvement, though the user doesn't see the underlying capability reason.

### Freeze protection validation + gating ([#112](https://github.com/eman/nwp500-python/issues/112))

`set_freeze_protection_temperature` now validates against the device's reported `freeze_protection_temp_min`/`_max` and is gated on `freeze_protection_use`. This integration never calls that command — it only reads those fields as sensor attributes. No impact.

### Confirmed write helpers ([#111](https://github.com/eman/nwp500-python/issues/111))

New opt-in `update_reservations_confirmed()` / `configure_tou_schedule_confirmed()` plus `canonical()` schedule comparison. **Not adopted here** — see below.

### `decode_reservation_hex` docstring ([#113](https://github.com/eman/nwp500-python/issues/113))

Documentation only.

## Verification

- 205 tests pass
- ruff check + format clean
- HACS validation passes
- mypy reports the same 12 pre-existing errors as before the bump (no new ones)

## Follow-up worth considering

The new confirmed-write helpers fix a real gap here. `async_update_reservations` (`coordinator.py:989`) and `async_configure_tou_schedule` (`coordinator.py:1045`) currently return `True` as soon as the MQTT publish succeeds, so the `update_reservations` and `configure_tou_schedule` services — and the schedule card at `www/nwp500-schedule-card.js:142` — report success even if the device never applied the schedule.

Left out of this PR deliberately: switching to the confirmed variants changes service semantics (the call would block awaiting the device's `rsv/rd`/`tou/rd` echo, and can time out), which users would notice.