### PR TITLE
chore: Remove unreachable AWS CRT error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,8 +63,6 @@
     adopting the confirmed variants is tracked separately.
   - Documentation fix to the `decode_reservation_hex` docstring
     ([issue #113](https://github.com/eman/nwp500-python/issues/113)).
-
-### Changed
 - **Removed unreachable AWS CRT error handling**: Since `nwp500-python` v9.2.0,
   `NavienMqttClient.publish()` no longer lets `awscrt` exceptions escape — a
   clean-session cancellation during reconnection is enqueued in the library's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,19 @@
   - Documentation fix to the `decode_reservation_hex` docstring
     ([issue #113](https://github.com/eman/nwp500-python/issues/113)).
 
+### Changed
+- **Removed unreachable AWS CRT error handling**: Since `nwp500-python` v9.2.0,
+  `NavienMqttClient.publish()` no longer lets `awscrt` exceptions escape — a
+  clean-session cancellation during reconnection is enqueued in the library's
+  command queue and returns normally, and any other AWS CRT failure is wrapped
+  in `MqttPublishError`. The integration's own
+  `AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION` special-casing on the command
+  path was therefore dead code and has been removed, along with the
+  `get_aws_error_name()` helper. `MqttPublishError` is already covered by the
+  existing `MqttError` handler. `AwsCrtError` handling is retained for the
+  connect/disconnect path, where the library still propagates it. No functional
+  change.
+
 ## [0.16.2] - 2026-07-14
 
 ### Fixed

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -32,7 +32,7 @@ from .const import (
     MIN_RECONNECT_INTERVAL,
     SLOW_UPDATE_THRESHOLD,
 )
-from .mqtt_manager import NWP500MqttManager, get_aws_error_name
+from .mqtt_manager import NWP500MqttManager
 
 if TYPE_CHECKING:
     from nwp500 import (  # type: ignore[attr-defined]
@@ -456,25 +456,6 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                                         self.devices
                                     )
                                 )
-                    except AwsCrtError as err:
-                        # Handle clean session cancellation gracefully
-                        # This occurs during MQTT reconnection and is expected
-                        # The command will be queued and retried automatically
-                        if (
-                            get_aws_error_name(err)
-                            == "AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION"
-                        ):
-                            _LOGGER.debug(
-                                "Status request queued due to MQTT "
-                                "reconnection for device %s",
-                                mac_address,
-                            )
-                        else:
-                            _LOGGER.error(
-                                "Failed to request status for device %s: %s",
-                                mac_address,
-                                err,
-                            )
                     except (RuntimeError, OSError) as err:
                         _LOGGER.error(
                             "Failed to request status for device %s: %s",

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -8,8 +8,6 @@ from collections import deque
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from awscrt.exceptions import AwsCrtError
-
 if TYPE_CHECKING:
     from nwp500 import (  # type: ignore[attr-defined]
         Device,
@@ -31,13 +29,6 @@ _LOGGER = logging.getLogger(__name__)
 # Reconnection backoff delays (seconds): 2s, 5s, 15s, 30s, 60s cap
 _RECONNECT_BACKOFF_DELAYS: list[float] = [2.0, 5.0, 15.0, 30.0, 60.0]
 _RECONNECTION_FAILED_EVENT = "reconnection_failed"
-
-
-def get_aws_error_name(exception: Any) -> str:
-    """Extract the name from an AwsCrtError safely."""
-    if isinstance(exception, AwsCrtError):
-        return str(getattr(exception, "name", ""))
-    return ""
 
 
 class NWP500MqttManager:
@@ -372,7 +363,7 @@ class NWP500MqttManager:
             return True
         except Exception as err:
             self.consecutive_timeouts += 1
-            return self._handle_aws_error(err, "status request")
+            return self._handle_command_error(err, "status request")
 
     async def request_device_info(self, device: Device) -> None:
         """Request device info."""
@@ -382,7 +373,7 @@ class NWP500MqttManager:
         try:
             await self.mqtt_client.ensure_device_info_cached(device)
         except Exception as err:
-            self._handle_aws_error(err, "device info request")
+            self._handle_command_error(err, "device info request")
 
     async def send_command(
         self, device: Device, command: str, **kwargs: Any
@@ -480,12 +471,12 @@ class NWP500MqttManager:
             try:
                 await self.mqtt_client.request_device_status(device)
             except Exception as err:
-                self._handle_aws_error(err, "post-command status request")
+                self._handle_command_error(err, "post-command status request")
 
             return True
 
         except Exception as err:
-            return self._handle_aws_error(err, f"command {command}")
+            return self._handle_command_error(err, f"command {command}")
 
     async def force_reconnect(self, devices: list[Device]) -> bool:
         """Force reconnection with exponential backoff.
@@ -566,19 +557,18 @@ class NWP500MqttManager:
         finally:
             self.reconnection_in_progress = False
 
-    def _handle_aws_error(self, err: Exception, context: str) -> bool:
-        """Handle AWS CRT errors gracefully.
+    def _handle_command_error(self, err: Exception, context: str) -> bool:
+        """Log a failed device command.
+
+        As of nwp500-python 9.2.0, NavienMqttClient.publish() no longer lets
+        awscrt exceptions escape: a clean-session cancellation during
+        reconnection is enqueued in the library's command queue and returns
+        normally, and any other AWS CRT failure is wrapped in MqttPublishError.
+        So every exception reaching here is a genuine failure.
 
         Returns:
-            bool: True if error was handled gracefully (e.g. queued), False otherwise.
+            bool: Always False - the command did not succeed.
         """
-        if isinstance(err, AwsCrtError):
-            error_name = get_aws_error_name(err)
-            if error_name == "AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION":
-                _LOGGER.debug(
-                    "Operation '%s' queued due to reconnection", context
-                )
-                return True
         _LOGGER.error("Error during %s: %s", context, err)
         return False
 

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -558,7 +558,11 @@ class NWP500MqttManager:
             self.reconnection_in_progress = False
 
     def _handle_command_error(self, err: Exception, context: str) -> bool:
-        """Log a failed device command.
+        """Log a failed outbound MQTT request.
+
+        Covers every publish-backed call this manager makes: control commands,
+        status requests, device-info requests, and the post-command status
+        refresh. The caller passes `context` to identify which one failed.
 
         As of nwp500-python 9.2.0, NavienMqttClient.publish() no longer lets
         awscrt exceptions escape: a clean-session cancellation during
@@ -566,8 +570,12 @@ class NWP500MqttManager:
         normally, and any other AWS CRT failure is wrapped in MqttPublishError.
         So every exception reaching here is a genuine failure.
 
+        Args:
+            err: The exception raised by the library call.
+            context: Short description of the operation, used in the log line.
+
         Returns:
-            bool: Always False - the command did not succeed.
+            bool: Always False - the request did not succeed.
         """
         _LOGGER.error("Error during %s: %s", context, err)
         return False

--- a/tests/unit/test_mqtt_manager.py
+++ b/tests/unit/test_mqtt_manager.py
@@ -6,12 +6,8 @@ import asyncio
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
-from awscrt.exceptions import AwsCrtError
 
-from custom_components.nwp500.mqtt_manager import (
-    NWP500MqttManager,
-    get_aws_error_name,
-)
+from custom_components.nwp500.mqtt_manager import NWP500MqttManager
 
 
 @pytest.fixture
@@ -200,25 +196,38 @@ async def test_send_command_success(manager, mock_mqtt_client, mock_device):
 
 @pytest.mark.asyncio
 async def test_send_command_queued(manager, mock_mqtt_client, mock_device):
-    """Test sending a command that gets queued due to clean session."""
+    """Test a command queued by the library during reconnection.
+
+    Since nwp500-python 9.2.0, a clean-session cancellation is enqueued in the
+    library's command queue and publish() returns 0 instead of raising, so the
+    command is reported as accepted.
+    """
     await manager.setup()
 
-    # Simulate AwsCrtError for clean session
-    # We need to mock the exception object to have the name attribute
-    error = AwsCrtError(
-        code=0,
-        name="AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION",
-        message="Clean session",
-    )
-    # If name is not set by constructor (depends on version), force it
-    error.name = "AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION"
-
-    mock_mqtt_client.set_power.side_effect = error
+    mock_mqtt_client.set_power.return_value = 0  # 0 == queued by the library
 
     result = await manager.send_command(mock_device, "set_power", power_on=True)
 
-    assert result is True  # Should return True as it's queued
+    assert result is True
     mock_mqtt_client.set_power.assert_called_with(mock_device, True)
+
+
+@pytest.mark.asyncio
+async def test_send_command_publish_error(
+    manager, mock_mqtt_client, mock_device
+):
+    """Test that a wrapped MqttPublishError is reported as a failure."""
+    from nwp500 import MqttPublishError
+
+    await manager.setup()
+
+    mock_mqtt_client.set_power.side_effect = MqttPublishError(
+        "Failed to publish to MQTT topic", retriable=True
+    )
+
+    result = await manager.send_command(mock_device, "set_power", power_on=True)
+
+    assert result is False
 
 
 @pytest.mark.asyncio
@@ -469,29 +478,6 @@ async def test_send_command_request_reservations(
 
     assert result is True
     mock_mqtt_client.request_reservations.assert_called_once_with(mock_device)
-
-
-def test_get_aws_error_name_with_awscrterror():
-    """Test get_aws_error_name extracts name from AwsCrtError."""
-    error = AwsCrtError(
-        code=0,
-        name="AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION",
-        message="Test error",
-    )
-    error.name = "AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION"
-
-    result = get_aws_error_name(error)
-
-    assert result == "AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION"
-
-
-def test_get_aws_error_name_with_regular_exception():
-    """Test get_aws_error_name returns empty string for non-AWS errors."""
-    error = RuntimeError("Regular error")
-
-    result = get_aws_error_name(error)
-
-    assert result == ""
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Follow-up cleanup to the v9.2.0 adoption (`04b2607`). Behavior-preserving.

## Why this is dead code

Since nwp500-python v9.2.0 ([#101](https://github.com/eman/nwp500-python/issues/101)), `NavienMqttClient.publish()` no longer lets `awscrt` exceptions escape the public API boundary (`nwp500/mqtt/client.py:964-997`):

- a clean-session cancellation during reconnection is enqueued in the library's command queue and `publish()` returns `0` instead of raising
- any other AWS CRT failure is wrapped in `MqttPublishError`

`enable_command_queue` defaults to `True` and this integration doesn't override it, so the clean-session branch always queues.

Every command path here is publish-backed (`request_status`, `request_device_info`, `send_command`, post-command status → `control.py::_send_command` → `_publish` → `client.publish`; `control.py` doesn't import `awscrt` at all). So the `AWS_ERROR_MQTT_CANCELLED_FOR_CLEAN_SESSION` special-casing could no longer fire.

## Changes

| Removed | Why |
|---|---|
| `_handle_aws_error()` clean-session branch | Unreachable per above |
| `get_aws_error_name()` + the `awscrt` import in `mqtt_manager.py` | No callers left |
| `except AwsCrtError` in the coordinator update loop | Same publish path |

`_handle_aws_error()` is renamed to `_handle_command_error()`, since everything reaching it is now a genuine failure.

## What is deliberately kept

`AwsCrtError` handling in `coordinator._async_setup_clients` stays — the library still propagates it from `connect()`/`disconnect()` (`nwp500/mqtt/connection.py:254`, `client.py:523`). That path is **not** dead.

Error handling is unchanged in practice: `MqttPublishError` is already covered by the coordinator's existing `(TimeoutError, MqttError)` handler on the same `try`.

## Tests

- The clean-session test now asserts the queued-returns-`0` contract rather than a raised `AwsCrtError`
- New `test_send_command_publish_error` covers `MqttPublishError` being reported as a failure
- The two `get_aws_error_name` unit tests are removed along with the helper

## Verification

- 204 tests pass, 82.04% coverage
- ruff check + format clean
- mypy goes from 12 errors to 11 — the removed `awscrt` import was one of them, and no new errors were introduced

`basedpyright`'s tox env isn't built locally, so CI will need to confirm that one.