### PR TITLE
fix: Unbreak Lint (ruff) CI job under ruff 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,9 @@
   the `Lint (ruff)` job on every pull request: two ```` ```python ```` blocks in
   `scripts/README.md` are illustrative listings of deprecated API names with
   deliberately aligned trailing comments, not runnable code. Retags those two
-  blocks as ```` ```text ```` and pins the environment to `ruff>=0.16.0,<0.17.0`
-  so local and CI runs agree and a future ruff release cannot break unrelated
-  pull requests.
+  blocks as ```` ```text ```` so the formatter leaves the alignment alone, and
+  raises the floor to `ruff>=0.16.0` so a local run cannot silently pass with an
+  older ruff than CI uses.
 
 ## [0.16.2] - 2026-07-14
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 ## [Unreleased]
 
+### Fixed
+- **CI: ruff 0.16.0 format check**: The `ruff` tox environment declared
+  `ruff>=0.1.0`, so CI floated to whatever ruff had most recently released.
+  ruff 0.16.0 began formatting fenced code blocks inside Markdown, which broke
+  the `Lint (ruff)` job on every pull request: two ```` ```python ```` blocks in
+  `scripts/README.md` are illustrative listings of deprecated API names with
+  deliberately aligned trailing comments, not runnable code. Retags those two
+  blocks as ```` ```text ```` and pins the environment to `ruff>=0.16.0,<0.17.0`
+  so local and CI runs agree and a future ruff release cannot break unrelated
+  pull requests.
+
 ## [0.16.2] - 2026-07-14
 
 ### Fixed

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -66,7 +66,7 @@ python3 scripts/check_deprecated_apis.py
 ### Examples
 
 **Will flag:**
-```python
+```text
 async_get_registry()          # Use specific registries
 get_registry()                # Use async_get instead
 ENTITY_ID_ALL_ATTRS          # Removed in 2022.2+
@@ -74,7 +74,7 @@ EntityComponent()             # Use entity platform instead
 ```
 
 **Will not flag (whitelisted):**
-```python
+```text
 async_add_entities()          # Standard platform method
 STATE_UNKNOWN                 # Valid state constants
 from homeassistant.const      # Standard imports

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands_pre =
 [testenv:ruff]
 description = Run ruff linting and formatting checks
 deps =
-    ruff>=0.16.0,<0.17.0
+    ruff>=0.16.0
 skip_install = True
 commands_pre =
 commands =

--- a/tox.ini
+++ b/tox.ini
@@ -38,7 +38,7 @@ commands_pre =
 [testenv:ruff]
 description = Run ruff linting and formatting checks
 deps =
-    ruff>=0.1.0
+    ruff>=0.16.0,<0.17.0
 skip_install = True
 commands_pre =
 commands =


### PR DESCRIPTION
**This is blocking #107, #108 and #109** — all three fail `Lint (ruff)` for this reason, not because of anything in them. Merging this first should clear them.

## Problem

The `ruff` tox environment declared `ruff>=0.1.0`, so CI floats to whatever ruff most recently released. ruff **0.16.0** began formatting fenced code blocks inside Markdown, and `ruff format --check` now fails:

```
ruff: ruff==0.16.0
ruff: commands[1]> ruff format --check custom_components/nwp500 tests scripts
unformatted: File would be reformatted
  --> scripts/README.md:1:1
1 file would be reformatted, 31 files already formatted
```

I confirmed this reproduces on a clean `main` with ruff 0.16.0, so it is pre-existing and unrelated to the open PRs. It breaks the job on every pull request, including ones that touch no Python at all.

## Fix

The two flagged blocks are illustrative listings of deprecated HA API names with deliberately aligned trailing comments, not runnable code:

```
async_get_registry()          # Use specific registries
get_registry()                # Use async_get instead
ENTITY_ID_ALL_ATTRS          # Removed in 2022.2+
EntityComponent()             # Use entity platform instead
```

ruff wanted to collapse that alignment to a single space. The second block isn't even valid Python — it contains a bare `from homeassistant.const`. Retagged both from ```` ```python ```` to ```` ```text ```` so the formatter leaves them alone.

## On the version constraint

`ruff>=0.1.0` → `ruff>=0.16.0`.

The floor matters: my locally installed ruff 0.15.20 reported everything clean while CI's 0.16.0 failed, so local checks were giving false green. Requiring `>=0.16.0` means a local run can't be older than what CI exercises.

No upper bound. An earlier revision of this PR capped it at `<0.17.0`; that's been dropped, since nothing in this repo would raise the cap and it would block 0.17 once it ships. (ruff 0.17 does not exist yet — 0.16.0 is the current release.) New ruff versions are now picked up automatically, with the tradeoff that a future release can break this job again the same way — the fix at that point is the same as here.

## Verification

With ruff 0.16.0, matching CI exactly:

```
ruff check custom_components/nwp500 tests scripts           -> All checks passed!
ruff format --check custom_components/nwp500 tests scripts  -> 32 files already formatted
```