### PR TITLE
fix: Accept Sunday and every-day masks in configure_tou_schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 ## [Unreleased]
 
 ### Fixed
+- **`configure_tou_schedule` rejected Sunday and every-day periods**: the
+  service validated each period's `week` bitfield with `Range(min=0, max=127)`,
+  which excludes bit 7 (Sunday = 128) and therefore every Sunday-inclusive
+  mask, including "every day" = 254. TOU uses the same weekday bitfield as
+  reservations (`Sun=128..Sat=2`), and the reservation validator in the same
+  file already allowed `0-254`. Raised the TOU bound to match, added the same
+  explanatory message, and corrected the `services.yaml` field description,
+  which also documented `0-127`. Fixes
+  [issue #106](https://github.com/eman/ha_nwp500/issues/106).
 - **CI: ruff 0.16.0 format check**: The `ruff` tox environment declared
   `ruff>=0.1.0`, so CI floated to whatever ruff had most recently released.
   ruff 0.16.0 began formatting fenced code blocks inside Markdown, which broke

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -236,7 +236,8 @@ SERVICE_CONFIGURE_TOU_SCHEMA = vol.All(
                             ),
                             vol.Required("week"): vol.All(
                                 vol.Coerce(int),
-                                vol.Range(min=0, max=127),
+                                vol.Range(min=0, max=254),
+                                msg="Week must be a bitfield (0-254, Sun=128..Sat=2)",
                             ),
                             vol.Required("start_hour"): vol.All(
                                 vol.Coerce(int),

--- a/custom_components/nwp500/services.yaml
+++ b/custom_components/nwp500/services.yaml
@@ -369,7 +369,8 @@ configure_tou_schedule:
       name: TOU Periods
       description: >-
         List of TOU period entries (max 16). Each entry is a dictionary with
-        keys: season (month bitfield 0-4095), week (day bitfield 0-127),
+        keys: season (month bitfield 0-4095), week (day bitfield 0-254,
+        Sun=128..Sat=2),
         start_hour (0-23), start_minute (0-59), end_hour (0-23),
         end_minute (0-59), price_min (encoded price), price_max (encoded price),
         decimal_point (decimal places for price).

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -21,6 +21,7 @@ from custom_components.nwp500 import (
     ATTR_TEMPERATURE,
     SERVICE_CLEAR_RESERVATIONS,
     SERVICE_CONFIGURE_TOU,
+    SERVICE_CONFIGURE_TOU_SCHEMA,
     SERVICE_DISABLE_DEMAND_RESPONSE,
     SERVICE_ENABLE_DEMAND_RESPONSE,
     SERVICE_REQUEST_RESERVATIONS,
@@ -31,6 +32,7 @@ from custom_components.nwp500 import (
     SERVICE_SET_VACATION_DAYS,
     SERVICE_TRIGGER_RECIRCULATION,
     SERVICE_UPDATE_RESERVATIONS,
+    SERVICE_UPDATE_RESERVATIONS_SCHEMA,
     _async_setup_services,
     validate_reservation_temperature,
 )
@@ -1003,3 +1005,80 @@ class TestDemandResponseAndRecirculationServices:
             HomeAssistantError, match="Failed to trigger recirculation"
         ):
             await handler(call)
+
+
+class TestTOUWeekBitfieldValidation:
+    """Validate the configure_tou_schedule 'week' bitfield bounds.
+
+    The TOU 'week' field uses the same weekday bitfield as reservations --
+    Sun=bit7 (128) through Sat=bit1 (2) -- so Sunday-inclusive masks and the
+    every-day mask (254) must be accepted. See issue #106.
+    """
+
+    @staticmethod
+    def _period(week: int) -> dict[str, int]:
+        return {
+            "season": 4095,
+            "week": week,
+            "start_hour": 0,
+            "start_minute": 0,
+            "end_hour": 6,
+            "end_minute": 0,
+            "price_min": 10,
+            "price_max": 20,
+            "decimal_point": 2,
+        }
+
+    @pytest.mark.parametrize(
+        "week",
+        [
+            0,  # no days
+            2,  # Saturday only (bit 1)
+            128,  # Sunday only (bit 7) -- rejected before the fix
+            130,  # Sunday + Saturday
+            254,  # every day -- rejected before the fix
+        ],
+    )
+    def test_accepts_valid_week_bitfields(self, week):
+        """Sunday-inclusive and every-day masks must validate."""
+        result = SERVICE_CONFIGURE_TOU_SCHEMA(
+            {
+                ATTR_DEVICE_ID: "device_123",
+                ATTR_PERIODS: [self._period(week)],
+            }
+        )
+        assert result[ATTR_PERIODS][0]["week"] == week
+
+    @pytest.mark.parametrize("week", [-1, 255, 256])
+    def test_rejects_out_of_range_week(self, week):
+        """Values outside the 0-254 bitfield range are still rejected."""
+        with pytest.raises(vol.Invalid):
+            SERVICE_CONFIGURE_TOU_SCHEMA(
+                {
+                    ATTR_DEVICE_ID: "device_123",
+                    ATTR_PERIODS: [self._period(week)],
+                }
+            )
+
+    def test_reservation_and_tou_week_bounds_agree(self):
+        """Both services share one weekday bitfield, so bounds must match."""
+        reservation = {
+            "enable": 2,
+            "week": 254,
+            "hour": 6,
+            "min": 30,
+            "mode": 4,
+            "param": 120,
+        }
+        SERVICE_UPDATE_RESERVATIONS_SCHEMA(
+            {
+                ATTR_DEVICE_ID: "device_123",
+                ATTR_RESERVATIONS: [reservation],
+            }
+        )
+        SERVICE_CONFIGURE_TOU_SCHEMA(
+            {
+                ATTR_DEVICE_ID: "device_123",
+                ATTR_PERIODS: [self._period(254)],
+            }
+        )


### PR DESCRIPTION
Fixes #106.

## Confirmed

The `configure_tou_schedule` service validated each period's `week` bitfield with `Range(min=0, max=127)` (`__init__.py:237-240`), but TOU `week` uses the same weekday bitfield as reservations — `Sun=bit7 (128)` through `Sat=bit1 (2)`.

Verified against the installed library:

```
nwp500/models/tou.py:65
    - week: bitfield of active weekdays (Sun=bit7, …, Sat=bit1)

nwp500/models/tou.py:160  (the library's own documented example)
    {"season": 4095, "week": 254, ...}
```

So `max=127` excluded bit 7 and rejected any Sunday-inclusive mask, including "every day" = 254 — before the request ever reached the device. The reservation validator in the same file already used `Range(min=0, max=254)` with the message `"Week must be a bitfield (0-254, Sun=128..Sat=2)"`, so the two services disagreed about a bitfield they share.

## Fix

- `__init__.py`: TOU `week` bound `127` → `254`, plus the same explanatory `msg` the reservation validator already had.
- `services.yaml`: the field description also documented `week (day bitfield 0-127)`; corrected to `0-254, Sun=128..Sat=2`.

I checked for other stale `0-127` references (`strings.json`, `translations/en.json`) — there are none.

## Tests

New `TestTOUWeekBitfieldValidation` covering:

| Case | `week` | Expected |
|---|---|---|
| No days | `0` | accept |
| Saturday only (bit 1) | `2` | accept |
| **Sunday only (bit 7)** | `128` | accept — **rejected before this fix** |
| **Sunday + Saturday** | `130` | accept — **rejected before this fix** |
| **Every day** | `254` | accept — **rejected before this fix** |
| Out of range | `-1`, `255`, `256` | reject |

Plus `test_reservation_and_tou_week_bounds_agree`, which pushes `week: 254` through *both* service schemas so the two can't drift apart again.

I verified these tests genuinely catch the bug by temporarily restoring `max=127` — 4 of the 9 fail, then pass once the fix is back.

## Verification

213 tests pass (up from 204), ruff clean, mypy unchanged at 11 pre-existing errors.