### PR TITLE
fix: Correct reservation/vacation service docs and stop file drift

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,22 @@
 ## [Unreleased]
 
 ### Fixed
+- **Reservation and vacation service documentation corrected**: three
+  descriptions contradicted the code or the library. The `update_reservations`
+  `reservations` field documented `enable (1=enabled, 2=disabled)`, which is
+  inverted — the device bool convention is `2=on, 1=off`
+  (`ReservationEntry.enabled` is `enable == 2`), as the service's own
+  validation message already said. `set_reservation` claimed the device
+  supports "up to 7 reservation entries" while the library documents ~16.
+  `set_vacation_days` described a 1-365 day range while its own field
+  description, selector and validator all cap at 30, which is what the library
+  enforces. Also synchronized `services.yaml` with `strings.json` and
+  `translations/en.json`, which had drifted independently: six `entity_id`
+  fields were missing from the strings files entirely, two service
+  descriptions were truncated, and the TOU `periods` description had lost its
+  field-by-field key list. Adds tests pinning the three files together so they
+  cannot drift again. Fixes
+  [issue #105](https://github.com/eman/ha_nwp500/issues/105).
 - **`configure_tou_schedule` rejected Sunday and every-day periods**: the
   service validated each period's `week` bitfield with `Range(min=0, max=127)`,
   which excludes bit 7 (Sunday = 128) and therefore every Sunday-inclusive

--- a/custom_components/nwp500/services.yaml
+++ b/custom_components/nwp500/services.yaml
@@ -5,7 +5,7 @@ set_reservation:
   description: >-
     Create or update a single reservation schedule entry. Reservations allow
     automatic mode and temperature changes at scheduled times. The device
-    supports up to 7 reservation entries.
+    supports up to 16 reservation entries.
   fields:
     device_id:
       name: Device
@@ -129,7 +129,7 @@ update_reservations:
       name: Reservations
       description: >-
         List of reservation entries. Each entry should be a dictionary with keys:
-        enable (1=enabled, 2=disabled), week (day bitfield), hour (0-23),
+        enable (2=enabled, 1=disabled), week (day bitfield), hour (0-23),
         min (0-59), mode (1-6), param (temperature in half-degrees Celsius).
         Use the set_reservation service for a simpler interface.
       required: true
@@ -255,7 +255,7 @@ set_vacation_days:
   name: Set Vacation Days
   description: >-
     Configure vacation mode duration. Sets the device to vacation mode for
-    the specified number of days (1-365). Vacation mode reduces energy
+    the specified number of days (1-30). Vacation mode reduces energy
     consumption during extended absences.
   fields:
     device_id:
@@ -306,7 +306,9 @@ set_recirculation_mode:
           integration: nwp500
     mode:
       name: Mode
-      description: Recirculation pump operation mode
+      description: >-
+        Recirculation pump operation mode: 1=Always On, 2=Button/On Demand,
+        3=Schedule, 4=Temperature Triggered
       required: true
       selector:
         select:

--- a/custom_components/nwp500/strings.json
+++ b/custom_components/nwp500/strings.json
@@ -431,7 +431,7 @@
   "services": {
     "set_reservation": {
       "name": "Set Reservation",
-      "description": "Create or update a single reservation schedule entry. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 7 reservation entries.",
+      "description": "Create or update a single reservation schedule entry. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 16 reservation entries.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -460,6 +460,10 @@
         "temperature": {
           "name": "Temperature",
           "description": "Target temperature in Fahrenheit (80-150°F). Required for heating modes, ignored for vacation and power off modes."
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -473,11 +477,15 @@
         },
         "reservations": {
           "name": "Reservations",
-          "description": "List of reservation entries. Each entry should be a dictionary with keys: enable (1=enabled, 2=disabled), week (day bitfield), hour (0-23), min (0-59), mode (1-6), param (temperature in half-degrees Celsius). Use the set_reservation service for a simpler interface."
+          "description": "List of reservation entries. Each entry should be a dictionary with keys: enable (2=enabled, 1=disabled), week (day bitfield), hour (0-23), min (0-59), mode (1-6), param (temperature in half-degrees Celsius). Use the set_reservation service for a simpler interface."
         },
         "enabled": {
           "name": "System Enabled",
           "description": "Whether the reservation system is enabled overall"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -488,6 +496,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -498,6 +510,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -595,7 +611,7 @@
     },
     "configure_tou_schedule": {
       "name": "Configure TOU Schedule",
-      "description": "Configure the Time of Use (TOU) pricing schedule on the device. Up to 16 periods can be defined with seasonal, weekly, and time-based pricing information.",
+      "description": "Configure the Time of Use (TOU) pricing schedule on the device. Up to 16 periods can be defined with seasonal, weekly, and time-based pricing information. The device uses this to optimize heating based on electricity rates.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -603,21 +619,29 @@
         },
         "periods": {
           "name": "TOU Periods",
-          "description": "List of TOU period entries with season, week, time, and price fields."
+          "description": "List of TOU period entries (max 16). Each entry is a dictionary with keys: season (month bitfield 0-4095), week (day bitfield 0-254, Sun=128..Sat=2), start_hour (0-23), start_minute (0-59), end_hour (0-23), end_minute (0-59), price_min (encoded price), price_max (encoded price), decimal_point (decimal places for price)."
         },
         "enabled": {
           "name": "Enabled",
           "description": "Whether the TOU scheduling system is enabled"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
     "request_tou_settings": {
       "name": "Request TOU Settings",
-      "description": "Request the current Time of Use (TOU) schedule configuration from the device. The response will be stored and fired as a nwp500_tou_updated event.",
+      "description": "Request the current Time of Use (TOU) schedule configuration from the device. The response will be stored in the coordinator and fired as a nwp500_tou_updated event.",
       "fields": {
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     }

--- a/custom_components/nwp500/translations/en.json
+++ b/custom_components/nwp500/translations/en.json
@@ -431,7 +431,7 @@
   "services": {
     "set_reservation": {
       "name": "Set Reservation",
-      "description": "Create or update a single reservation schedule entry. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 7 reservation entries.",
+      "description": "Create or update a single reservation schedule entry. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 16 reservation entries.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -459,7 +459,11 @@
         },
         "temperature": {
           "name": "Temperature",
-          "description": "Target temperature in Fahrenheit (80-150\u00b0F). Required for heating modes, ignored for vacation and power off modes."
+          "description": "Target temperature in Fahrenheit (80-150°F). Required for heating modes, ignored for vacation and power off modes."
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -473,11 +477,15 @@
         },
         "reservations": {
           "name": "Reservations",
-          "description": "List of reservation entries. Each entry should be a dictionary with keys: enable (1=enabled, 2=disabled), week (day bitfield), hour (0-23), min (0-59), mode (1-6), param (temperature in half-degrees Celsius). Use the set_reservation service for a simpler interface."
+          "description": "List of reservation entries. Each entry should be a dictionary with keys: enable (2=enabled, 1=disabled), week (day bitfield), hour (0-23), min (0-59), mode (1-6), param (temperature in half-degrees Celsius). Use the set_reservation service for a simpler interface."
         },
         "enabled": {
           "name": "System Enabled",
           "description": "Whether the reservation system is enabled overall"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -488,6 +496,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -498,6 +510,10 @@
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
@@ -595,7 +611,7 @@
     },
     "configure_tou_schedule": {
       "name": "Configure TOU Schedule",
-      "description": "Configure the Time of Use (TOU) pricing schedule on the device. Up to 16 periods can be defined with seasonal, weekly, and time-based pricing information.",
+      "description": "Configure the Time of Use (TOU) pricing schedule on the device. Up to 16 periods can be defined with seasonal, weekly, and time-based pricing information. The device uses this to optimize heating based on electricity rates.",
       "fields": {
         "device_id": {
           "name": "Device",
@@ -603,21 +619,29 @@
         },
         "periods": {
           "name": "TOU Periods",
-          "description": "List of TOU period entries with season, week, time, and price fields."
+          "description": "List of TOU period entries (max 16). Each entry is a dictionary with keys: season (month bitfield 0-4095), week (day bitfield 0-254, Sun=128..Sat=2), start_hour (0-23), start_minute (0-59), end_hour (0-23), end_minute (0-59), price_min (encoded price), price_max (encoded price), decimal_point (decimal places for price)."
         },
         "enabled": {
           "name": "Enabled",
           "description": "Whether the TOU scheduling system is enabled"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     },
     "request_tou_settings": {
       "name": "Request TOU Settings",
-      "description": "Request the current Time of Use (TOU) schedule configuration from the device. The response will be stored and fired as a nwp500_tou_updated event.",
+      "description": "Request the current Time of Use (TOU) schedule configuration from the device. The response will be stored in the coordinator and fired as a nwp500_tou_updated event.",
       "fields": {
         "device_id": {
           "name": "Device",
           "description": "The target NWP500 water heater device"
+        },
+        "entity_id": {
+          "name": "Entity",
+          "description": "The entity ID of the water heater (alternative to Device ID)"
         }
       }
     }

--- a/tests/unit/test_service_docs.py
+++ b/tests/unit/test_service_docs.py
@@ -1,0 +1,109 @@
+"""Consistency tests for the service documentation.
+
+The same service and field descriptions are duplicated across three files:
+``services.yaml`` (what Home Assistant renders in the UI), ``strings.json``
+and ``translations/en.json``. They drifted apart in issue #105 -- the
+``enable`` field was documented inverted in one place and the vacation range
+disagreed with its own validator -- so these tests pin the invariants that
+drift violates.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+import voluptuous as vol
+import yaml
+
+from custom_components.nwp500 import SERVICE_SET_VACATION_DAYS_SCHEMA
+
+COMPONENT = Path(__file__).parent.parent.parent / "custom_components" / "nwp500"
+
+
+def _load_yaml() -> dict:
+    with open(COMPONENT / "services.yaml", encoding="utf-8") as fh:
+        return yaml.safe_load(fh)
+
+
+def _load_json(name: str) -> dict:
+    with open(COMPONENT / name, encoding="utf-8") as fh:
+        return json.load(fh)
+
+
+@pytest.fixture(scope="module")
+def services_yaml() -> dict:
+    return _load_yaml()
+
+
+@pytest.fixture(scope="module", params=["strings.json", "translations/en.json"])
+def translations(request) -> dict:
+    return _load_json(request.param)["services"]
+
+
+def test_same_services_defined_everywhere(services_yaml, translations):
+    """Every service in services.yaml must be described in the strings files."""
+    assert set(services_yaml) == set(translations)
+
+
+def test_descriptions_match(services_yaml, translations):
+    """A service's description must be identical in both places.
+
+    Divergence here is exactly how the inverted `enable` documentation in
+    issue #105 survived: services.yaml was corrected in isolation before.
+    """
+    for name, spec in services_yaml.items():
+        expected = " ".join(spec["description"].split())
+        actual = " ".join(translations[name]["description"].split())
+        assert actual == expected, f"description drift in service '{name}'"
+
+
+def test_field_descriptions_match(services_yaml, translations):
+    """Each field's description must be identical in both places."""
+    for name, spec in services_yaml.items():
+        for field, fspec in (spec.get("fields") or {}).items():
+            if "description" not in fspec:
+                continue
+            expected = " ".join(fspec["description"].split())
+            actual = " ".join(
+                translations[name]["fields"][field]["description"].split()
+            )
+            assert actual == expected, f"description drift in '{name}.{field}'"
+
+
+def test_enable_documented_with_device_bool_convention(services_yaml):
+    """`enable` uses the device bool convention: 2=on, 1=off.
+
+    nwp500-python `ReservationEntry.enabled` is `self.enable == 2`, so
+    documenting 1 as enabled (issue #105) inverts the meaning.
+    """
+    description = services_yaml["update_reservations"]["fields"][
+        "reservations"
+    ]["description"]
+    assert "2=enabled" in description
+    assert "1=disabled" in description
+    assert "1=enabled" not in description
+
+
+@pytest.mark.parametrize("days", [1, 30])
+def test_vacation_description_matches_validator_bounds(services_yaml, days):
+    """The documented vacation range must be what the schema accepts.
+
+    The service description claimed 1-365 while the validator, the field
+    description and the selector all capped at 30 (issue #105).
+    """
+    SERVICE_SET_VACATION_DAYS_SCHEMA({"device_id": "d", "days": days})
+
+    spec = services_yaml["set_vacation_days"]
+    assert "1-30" in spec["description"]
+    assert "1-30" in spec["fields"]["days"]["description"]
+    selector = spec["fields"]["days"]["selector"]["number"]
+    assert (selector["min"], selector["max"]) == (1, 30)
+
+
+@pytest.mark.parametrize("days", [0, 31, 365])
+def test_vacation_validator_rejects_out_of_range(days):
+    """Values outside the documented range are rejected."""
+    with pytest.raises(vol.Invalid):
+        SERVICE_SET_VACATION_DAYS_SCHEMA({"device_id": "d", "days": days})

--- a/tests/unit/test_service_docs.py
+++ b/tests/unit/test_service_docs.py
@@ -59,6 +59,24 @@ def test_descriptions_match(services_yaml, translations):
         assert actual == expected, f"description drift in service '{name}'"
 
 
+def test_same_fields_defined_everywhere(services_yaml, translations):
+    """Each service must document the same field names in both places.
+
+    Checked separately from the descriptions so a missing or extra field
+    reports which key drifted, rather than surfacing as a KeyError. Six
+    `entity_id` fields were missing from the strings files in issue #105,
+    and an extra field there would otherwise go unnoticed entirely.
+    """
+    for name, spec in services_yaml.items():
+        expected = set(spec.get("fields") or {})
+        actual = set(translations[name].get("fields") or {})
+        assert actual == expected, (
+            f"field drift in service '{name}': "
+            f"missing from strings {sorted(expected - actual)}, "
+            f"unexpected in strings {sorted(actual - expected)}"
+        )
+
+
 def test_field_descriptions_match(services_yaml, translations):
     """Each field's description must be identical in both places."""
     for name, spec in services_yaml.items():
@@ -67,7 +85,9 @@ def test_field_descriptions_match(services_yaml, translations):
                 continue
             expected = " ".join(fspec["description"].split())
             actual = " ".join(
-                translations[name]["fields"][field]["description"].split()
+                translations[name]["fields"][field]
+                .get("description", "")
+                .split()
             )
             assert actual == expected, f"description drift in '{name}.{field}'"
 


### PR DESCRIPTION
Fixes #105.

## All three claims confirmed

### 1. `enable` documented inverted ✅

`services.yaml` documented `enable (1=enabled, 2=disabled)`. The device bool convention is the opposite:

```
nwp500/models/schedule.py:50
    """Whether this reservation is active (device bool: 2=on, 1=off)."""
    return self.enable == 2
```

The service's own validation message (`"Enable must be 2 (On) or 1 (Off)"`) was already correct, so only the field description was wrong — meaning anyone following the docs would have written entries that are disabled on the device.

### 2. Entry cap 7 vs ~16 ✅

Resolved from the [library docs](https://nwp500-python.readthedocs.io/en/latest/how-to/schedule-operation.html):

> "The device can store up to ~16 reservation entries."
> "The device supports up to 16 TOU periods."

`set_reservation` said 7. Corrected to 16, which also matches the `vol.Length(max=16)` the TOU service already enforces.

Note: the issue suggested sourcing this from a device feature field. That isn't possible — no `DeviceFeature` field reports a reservation cap. I left this as documentation rather than adding a hard validator, since the library hedges with "~16" and the integration currently enforces no cap on reservations at all.

### 3. Vacation range 1-365 vs 1-30 ✅

The library **enforces** the range:

```
nwp500/mqtt/control.py:384
    self._validate_range("vacation_days", vacation_days, 1, 30)
```

So 1-30 is operative. The field description, selector and validator were already correct; only the service-level description said 1-365. Corrected to 1-30.

The library's prose docs mention "0–99 days", which contradicts its own enforcement — worth raising upstream, but 1-30 is what actually works today.

## Additional drift found while writing the tests

`services.yaml`, `strings.json` and `translations/en.json` duplicate the same text and had drifted independently:

| Problem | Detail |
|---|---|
| Missing fields | `entity_id` absent from the strings files for **six** services — HA renders no translated description for them |
| Truncated | `configure_tou_schedule` and `request_tou_settings` descriptions cut short in the strings files |
| Lost detail | TOU `periods` reduced to "with season, week, time, and price fields", dropping the key-by-key list |

Synchronized all three, taking the richer wording in each case — `services.yaml` for most, the strings files for `set_recirculation_mode.mode`, which listed the mode numbers (`1=Always On, 2=Button/On Demand, …`) that `services.yaml` lacked.

## Tests

New `tests/unit/test_service_docs.py` (12 tests) pinning the invariants:

- every service in `services.yaml` exists in both strings files, with identical service **and** field descriptions
- `enable` is documented `2=enabled` / `1=disabled`, and never `1=enabled`
- the documented vacation range matches what `SERVICE_SET_VACATION_DAYS_SCHEMA` actually accepts, including the selector bounds, with `0`, `31` and `365` rejected

This class of drift now fails CI instead of shipping.

## Verification

225 tests pass (up from 213), ruff clean, HACS validation passes, mypy unchanged at 11 pre-existing errors.