### PR TITLE
fix: Stop set_reservation wiping the device's reservation schedule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,13 @@
   programming a different mode at a day and time already scheduled —
   accumulated conflicting entries with no way to update one in place. An
   entry occupying the same slot (same `week` bitfield, hour and minute) is
-  now replaced. Fixes
+  now replaced.
+- **`set_reservation` forced the device's reservation system on**: the
+  handler passed a hardcoded `enabled=True` to the full-list write, so
+  adding or updating a single entry silently re-enabled the schedule-wide
+  reservation switch on a device where it had been turned off. That switch
+  (`reservation_use`) is separate from this service's entry-level `enabled`
+  field, and is now preserved from the device's own reported state. Fixes
   [issue #104](https://github.com/eman/ha_nwp500/issues/104).
 - **`configure_tou_schedule` rejected Sunday and every-day periods**: the
   service validated each period's `week` bitfield with `Range(min=0, max=127)`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,23 @@
   field-by-field key list. Adds tests pinning the three files together so they
   cannot drift again. Fixes
   [issue #105](https://github.com/eman/ha_nwp500/issues/105).
+- **`set_reservation` could wipe every reservation on the device**: the
+  service does a read-modify-write against the cached reservation schedule,
+  but the write is a full-list replacement at the protocol level. When the
+  schedule had never been fetched the cache was empty, and the handler only
+  logged a warning before pushing a single-entry list — replacing every
+  reservation the device held. It now fetches the schedule and waits for the
+  device's response first, and raises an error rather than writing if the
+  schedule cannot be read. Adds `NWP500DataUpdateCoordinator.async_fetch_reservations()`,
+  which requests the schedule and awaits the reply, since
+  `async_request_reservations()` only publishes the request.
+- **`set_reservation` was append-only despite its name**: documented as
+  "create or update", the handler only appended, so repeating a call — or
+  programming a different mode at a day and time already scheduled —
+  accumulated conflicting entries with no way to update one in place. An
+  entry occupying the same slot (same `week` bitfield, hour and minute) is
+  now replaced. Fixes
+  [issue #104](https://github.com/eman/ha_nwp500/issues/104).
 - **`configure_tou_schedule` rejected Sunday and every-day periods**: the
   service validated each period's `week` bitfield with `Range(min=0, max=127)`,
   which excludes bit 7 (Sunday = 128) and therefore every Sunday-inclusive

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -533,8 +533,18 @@ class NWP500ServiceHandler:
                 list(existing_schedule.get("reservation", [])), reservation
             )
 
+            # This service's `enabled` field is entry-level. The device's
+            # global reservation switch is separate, so preserve whatever it
+            # currently is instead of forcing it on. `reservation_use` uses
+            # the device bool convention (2=on, 1=off); if the device did not
+            # report it, fall back to enabling.
+            reservation_use = existing_schedule.get("reservation_use")
+            system_enabled = (
+                True if reservation_use is None else reservation_use == 2
+            )
+
             success = await coordinator.async_update_reservations(
-                mac_address, existing_entries, enabled=True
+                mac_address, existing_entries, enabled=system_enabled
             )
 
         if not success:

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -103,6 +103,45 @@ VALID_MODES = [
 ]
 
 
+def _reservation_slot(entry: dict[str, Any]) -> tuple[int, int, int]:
+    """Return the schedule slot an entry occupies: (week, hour, minute).
+
+    Two entries with the same days and time are the same reservation, so
+    writing one replaces the other rather than stacking a duplicate.
+    """
+    return (
+        int(entry.get("week", 0)),
+        int(entry.get("hour", 0)),
+        int(entry.get("min", 0)),
+    )
+
+
+def _merge_reservation_entry(
+    entries: list[dict[str, Any]], new_entry: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Insert `new_entry`, replacing any entry in the same slot.
+
+    `set_reservation` is documented as "create or update". Without this it
+    only appended, so repeating a call -- or scheduling a different mode at
+    a day/time already programmed -- accumulated conflicting entries with
+    no way to update one in place.
+
+    Returns a new list; `entries` is not modified.
+    """
+    slot = _reservation_slot(new_entry)
+    merged = [e for e in entries if _reservation_slot(e) != slot]
+    replaced = len(merged) != len(entries)
+
+    if replaced:
+        _LOGGER.debug(
+            "Replacing existing reservation in slot week=%d %02d:%02d",
+            *slot,
+        )
+
+    merged.append(new_entry)
+    return merged
+
+
 def validate_reservation_temperature(data: dict[str, Any]) -> dict[str, Any]:
     """Validate that temperature is provided for modes that require it."""
     mode = data.get(ATTR_OP_MODE)
@@ -464,20 +503,35 @@ class NWP500ServiceHandler:
             coordinator.hass.config.units.temperature_unit,
         )
 
-        # Read-modify-write: append to existing schedule instead of replacing
+        # Read-modify-write. The write is a full-list replacement at the
+        # protocol level, so the read must reflect what the device actually
+        # holds -- writing from an empty cache would wipe every existing
+        # reservation.
         async with coordinator._reservation_lock:
             existing_schedule = coordinator.reservation_schedules.get(
                 mac_address, {}
             )
-            existing_entries = list(existing_schedule.get("reservation", []))
             if not existing_schedule:
-                _LOGGER.warning(
-                    "No cached reservation schedule for %s. Call "
-                    "request_reservations first to avoid overwriting device "
-                    "reservations that have not yet been fetched.",
+                _LOGGER.debug(
+                    "No cached reservation schedule for %s; fetching before "
+                    "write",
                     mac_address,
                 )
-            existing_entries.append(reservation)
+                existing_schedule = (
+                    await coordinator.async_fetch_reservations(mac_address)
+                    or {}
+                )
+            if not existing_schedule:
+                raise HomeAssistantError(
+                    f"Could not read the current reservation schedule for "
+                    f"{mac_address}. Refusing to write, because doing so "
+                    f"would replace every reservation on the device. Check "
+                    f"that the device is online and try again."
+                )
+
+            existing_entries = _merge_reservation_entry(
+                list(existing_schedule.get("reservation", [])), reservation
+            )
 
             success = await coordinator.async_update_reservations(
                 mac_address, existing_entries, enabled=True

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -1061,15 +1061,19 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         try:
             if not await self.async_request_reservations(mac_address):
                 return None
-            return await asyncio.wait_for(waiter, timeout=timeout)
-        except TimeoutError:
-            _LOGGER.warning(
-                "Timed out after %.0fs waiting for the reservation schedule "
-                "of %s",
-                timeout,
-                mac_address,
-            )
-            return None
+            # Only the wait is guarded, so a TimeoutError raised anywhere
+            # else (e.g. inside the publish above) propagates instead of
+            # being reported as "the device did not answer in time".
+            try:
+                return await asyncio.wait_for(waiter, timeout=timeout)
+            except TimeoutError:
+                _LOGGER.warning(
+                    "Timed out after %.0fs waiting for the reservation "
+                    "schedule of %s",
+                    timeout,
+                    mac_address,
+                )
+                return None
         finally:
             pending = self._reservation_waiters.get(mac_address)
             if pending and waiter in pending:

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -77,6 +77,13 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._reservation_lock = (
             asyncio.Lock()
         )  # Prevent reservation write race
+        # Futures awaiting a fresh rsv/rd response, keyed by MAC. Resolved by
+        # _handle_reservation_update_in_loop so a read-modify-write can wait
+        # for the device's actual schedule instead of guessing from an empty
+        # cache (see async_fetch_reservations).
+        self._reservation_waiters: dict[
+            str, list[asyncio.Future[dict[str, Any]]]
+        ] = {}
         self._device_info_request_counter: dict[
             str, int
         ] = {}  # Track fallback device info requests
@@ -867,6 +874,11 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
 
             self.reservation_schedules[mac_address] = response
 
+            # Wake anything waiting on a fresh read (async_fetch_reservations)
+            for waiter in self._reservation_waiters.pop(mac_address, []):
+                if not waiter.done():
+                    waiter.set_result(response)
+
             # Fire HA event so custom cards and automations can react
             self.hass.bus.async_fire(
                 "nwp500_reservations_updated",
@@ -1022,6 +1034,48 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return await self.mqtt_manager.send_command(
             device, "request_reservations"
         )
+
+    async def async_fetch_reservations(
+        self, mac_address: str, timeout: float = 10.0
+    ) -> dict[str, Any] | None:
+        """Request the reservation schedule and wait for the device's reply.
+
+        `async_request_reservations` only publishes the request; the reply
+        arrives asynchronously over MQTT. Callers that must not act on a
+        stale or empty cache -- notably the read-modify-write in
+        `set_reservation`, where writing is a full-list replacement -- need
+        the value itself, so this waits for the response.
+
+        Args:
+            mac_address: Device MAC address.
+            timeout: Seconds to wait for the device's response.
+
+        Returns:
+            The reservation schedule the device reported, or None if the
+            request could not be sent or no response arrived in time.
+        """
+        loop = asyncio.get_running_loop()
+        waiter: asyncio.Future[dict[str, Any]] = loop.create_future()
+        self._reservation_waiters.setdefault(mac_address, []).append(waiter)
+
+        try:
+            if not await self.async_request_reservations(mac_address):
+                return None
+            return await asyncio.wait_for(waiter, timeout=timeout)
+        except TimeoutError:
+            _LOGGER.warning(
+                "Timed out after %.0fs waiting for the reservation schedule "
+                "of %s",
+                timeout,
+                mac_address,
+            )
+            return None
+        finally:
+            pending = self._reservation_waiters.get(mac_address)
+            if pending and waiter in pending:
+                pending.remove(waiter)
+            if pending is not None and not pending:
+                self._reservation_waiters.pop(mac_address, None)
 
     async def async_configure_tou_schedule(
         self,

--- a/custom_components/nwp500/services.yaml
+++ b/custom_components/nwp500/services.yaml
@@ -3,9 +3,11 @@
 set_reservation:
   name: Set Reservation
   description: >-
-    Create or update a single reservation schedule entry. Reservations allow
-    automatic mode and temperature changes at scheduled times. The device
-    supports up to 16 reservation entries.
+    Create or update a single reservation schedule entry. An existing entry
+    scheduled for the same days and time is replaced, so repeating a call
+    updates it rather than adding a duplicate. Reservations allow automatic
+    mode and temperature changes at scheduled times. The device supports up
+    to 16 reservation entries.
   fields:
     device_id:
       name: Device

--- a/custom_components/nwp500/strings.json
+++ b/custom_components/nwp500/strings.json
@@ -431,7 +431,7 @@
   "services": {
     "set_reservation": {
       "name": "Set Reservation",
-      "description": "Create or update a single reservation schedule entry. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 16 reservation entries.",
+      "description": "Create or update a single reservation schedule entry. An existing entry scheduled for the same days and time is replaced, so repeating a call updates it rather than adding a duplicate. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 16 reservation entries.",
       "fields": {
         "device_id": {
           "name": "Device",

--- a/custom_components/nwp500/translations/en.json
+++ b/custom_components/nwp500/translations/en.json
@@ -431,7 +431,7 @@
   "services": {
     "set_reservation": {
       "name": "Set Reservation",
-      "description": "Create or update a single reservation schedule entry. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 16 reservation entries.",
+      "description": "Create or update a single reservation schedule entry. An existing entry scheduled for the same days and time is replaced, so repeating a call updates it rather than adding a duplicate. Reservations allow automatic mode and temperature changes at scheduled times. The device supports up to 16 reservation entries.",
       "fields": {
         "device_id": {
           "name": "Device",

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -1253,3 +1253,94 @@ class TestSetReservationRefusesUnfetchedWrite:
             await handler(self._call())
 
         coordinator.async_update_reservations.assert_not_called()
+
+
+class TestSetReservationPreservesGlobalSwitch:
+    """The device's global reservation switch is not this service's to change.
+
+    `set_reservation`'s `enabled` field is entry-level. The schedule-wide
+    switch is `reservation_use` (device bool: 2=on, 1=off), and the handler
+    used to force it on with a hardcoded `enabled=True`.
+    """
+
+    @staticmethod
+    def _coordinator(mock_hass, schedule):
+        import asyncio
+
+        coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        coordinator.hass = mock_hass
+        coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        coordinator.device_features = {}
+        coordinator.reservation_schedules = {"AA:BB:CC:DD:EE:FF": schedule}
+        coordinator._reservation_lock = asyncio.Lock()
+        coordinator.async_update_reservations = AsyncMock(return_value=True)
+        coordinator.async_request_reservations = AsyncMock(return_value=True)
+        coordinator.async_fetch_reservations = AsyncMock(return_value=schedule)
+        return coordinator
+
+    async def _run(self, mock_hass, mock_device_registry, schedule):
+        coordinator = self._coordinator(mock_hass, schedule)
+        mock_hass.data[DOMAIN]["entry_1"] = coordinator
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        await _async_setup_services(mock_hass)
+        handler = None
+        for registered in mock_hass.services.async_register.call_args_list:
+            if registered[0][1] == SERVICE_SET_RESERVATION:
+                handler = registered[0][2]
+                break
+
+        call = MagicMock(spec=ServiceCall)
+        call.data = {
+            ATTR_DEVICE_ID: "device_123",
+            ATTR_ENABLED: True,
+            ATTR_DAYS: ["Monday"],
+            ATTR_HOUR: 6,
+            ATTR_MINUTE: 30,
+            ATTR_OP_MODE: "energy_saver",
+            ATTR_TEMPERATURE: 140,
+        }
+        await handler(call)
+        return coordinator
+
+    @pytest.mark.asyncio
+    async def test_keeps_the_switch_off_when_device_has_it_off(
+        self, mock_hass, mock_device_registry
+    ):
+        """A disabled reservation system stays disabled."""
+        coordinator = await self._run(
+            mock_hass,
+            mock_device_registry,
+            {"reservation": [], "reservation_use": 1},
+        )
+
+        _, kwargs = coordinator.async_update_reservations.call_args
+        assert kwargs["enabled"] is False
+
+    @pytest.mark.asyncio
+    async def test_keeps_the_switch_on_when_device_has_it_on(
+        self, mock_hass, mock_device_registry
+    ):
+        """An enabled reservation system stays enabled."""
+        coordinator = await self._run(
+            mock_hass,
+            mock_device_registry,
+            {"reservation": [], "reservation_use": 2},
+        )
+
+        _, kwargs = coordinator.async_update_reservations.call_args
+        assert kwargs["enabled"] is True
+
+    @pytest.mark.asyncio
+    async def test_enables_when_device_did_not_report_the_switch(
+        self, mock_hass, mock_device_registry
+    ):
+        """With no reported value there is nothing to preserve."""
+        coordinator = await self._run(
+            mock_hass, mock_device_registry, {"reservation": []}
+        )
+
+        _, kwargs = coordinator.async_update_reservations.call_args
+        assert kwargs["enabled"] is True

--- a/tests/unit/test_services.py
+++ b/tests/unit/test_services.py
@@ -34,6 +34,7 @@ from custom_components.nwp500 import (
     SERVICE_UPDATE_RESERVATIONS,
     SERVICE_UPDATE_RESERVATIONS_SCHEMA,
     _async_setup_services,
+    _merge_reservation_entry,
     validate_reservation_temperature,
 )
 from custom_components.nwp500.const import (
@@ -148,7 +149,11 @@ class TestReservationServices:
         mock_coordinator.hass = mock_hass
         mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
         mock_coordinator.device_features = {}  # Add device_features
-        mock_coordinator.reservation_schedules = {}  # Required for read-modify-write
+        # A fetched-but-empty schedule. Distinct from {} (never fetched),
+        # which set_reservation now refuses to write from -- see issue #104.
+        mock_coordinator.reservation_schedules = {
+            "AA:BB:CC:DD:EE:FF": {"reservation": []}
+        }
         mock_coordinator._reservation_lock = (
             asyncio.Lock()
         )  # Add lock for async context
@@ -383,7 +388,11 @@ class TestReservationServices:
         mock_coordinator.hass = mock_hass
         mock_coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
         mock_coordinator.device_features = {}  # Add device_features
-        mock_coordinator.reservation_schedules = {}  # Required for read-modify-write
+        # A fetched-but-empty schedule. Distinct from {} (never fetched),
+        # which set_reservation now refuses to write from -- see issue #104.
+        mock_coordinator.reservation_schedules = {
+            "AA:BB:CC:DD:EE:FF": {"reservation": []}
+        }
         mock_coordinator._reservation_lock = (
             asyncio.Lock()
         )  # Add lock for async context
@@ -1082,3 +1091,165 @@ class TestTOUWeekBitfieldValidation:
                 ATTR_PERIODS: [self._period(254)],
             }
         )
+
+
+class TestReservationMergeSemantics:
+    """`set_reservation` is documented "create or update", not append.
+
+    Before issue #104 it only appended, so repeating a call -- or programming
+    a different mode at a day/time already scheduled -- accumulated
+    conflicting entries with no way to update one in place.
+    """
+
+    @staticmethod
+    def _entry(week=42, hour=6, minute=30, mode=3, param=120):
+        return {
+            "enable": 2,
+            "week": week,
+            "hour": hour,
+            "min": minute,
+            "mode": mode,
+            "param": param,
+        }
+
+    def test_replaces_entry_in_the_same_slot(self):
+        """Same days+time means the same reservation, so it is replaced."""
+        existing = [self._entry(mode=3, param=120)]
+        new = self._entry(mode=4, param=140)
+
+        result = _merge_reservation_entry(existing, new)
+
+        assert result == [new]
+
+    def test_appends_when_slot_is_free(self):
+        """A different day/time is a new reservation, so it is added."""
+        existing = [self._entry(hour=6)]
+        new = self._entry(hour=18)
+
+        result = _merge_reservation_entry(existing, new)
+
+        assert result == [existing[0], new]
+
+    def test_repeated_identical_calls_do_not_accumulate(self):
+        """Calling twice with the same slot leaves one entry, not two."""
+        entry = self._entry()
+
+        result = _merge_reservation_entry([], entry)
+        result = _merge_reservation_entry(result, entry)
+        result = _merge_reservation_entry(result, entry)
+
+        assert result == [entry]
+
+    def test_preserves_unrelated_entries(self):
+        """Other reservations survive an update to one slot."""
+        morning = self._entry(hour=6)
+        evening = self._entry(hour=18)
+        weekend = self._entry(week=130, hour=9)
+        updated_evening = self._entry(hour=18, mode=1, param=100)
+
+        result = _merge_reservation_entry(
+            [morning, evening, weekend], updated_evening
+        )
+
+        assert morning in result
+        assert weekend in result
+        assert updated_evening in result
+        assert evening not in result
+        assert len(result) == 3
+
+    def test_does_not_mutate_the_input_list(self):
+        """The caller's list is left alone."""
+        existing = [self._entry(hour=6)]
+        snapshot = [dict(e) for e in existing]
+
+        _merge_reservation_entry(existing, self._entry(hour=18))
+
+        assert existing == snapshot
+
+
+class TestSetReservationRefusesUnfetchedWrite:
+    """Writing is a full-list replacement, so an empty cache must not be used.
+
+    Before issue #104 an unfetched cache only logged a warning and then wrote
+    a single-entry list, wiping every reservation on the device.
+    """
+
+    @staticmethod
+    def _coordinator(mock_hass, *, fetch_result):
+        import asyncio
+
+        coordinator = MagicMock(spec=NWP500DataUpdateCoordinator)
+        coordinator.hass = mock_hass
+        coordinator.data = {"AA:BB:CC:DD:EE:FF": {}}
+        coordinator.device_features = {}
+        coordinator.reservation_schedules = {}  # never fetched
+        coordinator._reservation_lock = asyncio.Lock()
+        coordinator.async_update_reservations = AsyncMock(return_value=True)
+        coordinator.async_request_reservations = AsyncMock(return_value=True)
+        coordinator.async_fetch_reservations = AsyncMock(
+            return_value=fetch_result
+        )
+        return coordinator
+
+    @staticmethod
+    def _call():
+        call = MagicMock(spec=ServiceCall)
+        call.data = {
+            ATTR_DEVICE_ID: "device_123",
+            ATTR_ENABLED: True,
+            ATTR_DAYS: ["Monday"],
+            ATTR_HOUR: 6,
+            ATTR_MINUTE: 30,
+            ATTR_OP_MODE: "energy_saver",
+            ATTR_TEMPERATURE: 140,
+        }
+        return call
+
+    @staticmethod
+    async def _handler(mock_hass):
+        await _async_setup_services(mock_hass)
+        for registered in mock_hass.services.async_register.call_args_list:
+            if registered[0][1] == SERVICE_SET_RESERVATION:
+                return registered[0][2]
+        return None
+
+    @pytest.mark.asyncio
+    async def test_fetches_when_cache_is_empty(
+        self, mock_hass, mock_device_registry
+    ):
+        """An unfetched cache triggers a read before the write."""
+        coordinator = self._coordinator(
+            mock_hass, fetch_result={"reservation": []}
+        )
+        mock_hass.data[DOMAIN]["entry_1"] = coordinator
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        handler = await self._handler(mock_hass)
+        await handler(self._call())
+
+        coordinator.async_fetch_reservations.assert_awaited_once()
+        coordinator.async_update_reservations.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_refuses_to_write_when_fetch_fails(
+        self, mock_hass, mock_device_registry
+    ):
+        """If the schedule can't be read, nothing is written.
+
+        This is the data-loss guard: previously a single-entry list was
+        pushed as a full replacement, wiping the device's reservations.
+        """
+        coordinator = self._coordinator(mock_hass, fetch_result=None)
+        mock_hass.data[DOMAIN]["entry_1"] = coordinator
+        device_entry = MagicMock()
+        device_entry.identifiers = {(DOMAIN, "AA:BB:CC:DD:EE:FF")}
+        mock_device_registry.async_get = MagicMock(return_value=device_entry)
+
+        handler = await self._handler(mock_hass)
+
+        with pytest.raises(HomeAssistantError, match="Refusing to write"):
+            await handler(self._call())
+
+        coordinator.async_update_reservations.assert_not_called()


### PR DESCRIPTION
Fixes #104. Both reported problems confirmed by reading the handler.

## 1. Data loss from an unfetched cache

`set_reservation` does a read-modify-write against `coordinator.reservation_schedules`, but `async_update_reservations` is a **full-list replacement** at the protocol level. When the schedule had never been fetched the cache was empty, and the handler only logged a warning before proceeding:

```python
if not existing_schedule:
    _LOGGER.warning("No cached reservation schedule ... to avoid overwriting ...")
existing_entries.append(reservation)
success = await coordinator.async_update_reservations(mac_address, existing_entries, enabled=True)
```

That pushes a **single-entry list as a full replacement**, wiping every reservation on the device. A warning is not protection — the user has already lost the schedule by the time they read the log.

### Fix

Fetch and wait before writing; refuse if the schedule can't be read.

This needed a new coordinator method. `async_request_reservations()` only *publishes* the request — the reply arrives asynchronously via MQTT and lands in `reservation_schedules` through `_handle_reservation_update_in_loop`. So there was no way to wait for the value. `async_fetch_reservations()` registers a future, sends the request, and awaits the response with a timeout; `_handle_reservation_update_in_loop` resolves any waiters.

The fix relies on a distinction the old code collapsed:

| Cache state | Meaning | Safe to write from? |
|---|---|---|
| `{}` | never fetched | **No** — fetch first, and refuse if that fails |
| `{"reservation": []}` | fetched, device has none | Yes |

## 2. Append-only despite the "update" name

Documented as "create or update", but the handler only appended — no key, no dedup. Repeating a call, or programming a different mode at a day/time already scheduled, accumulated conflicting entries with no way to update one in place.

Now an entry occupying the same **slot** — same `week` bitfield, hour and minute — is replaced. Repeated calls become idempotent, and the service does what its name says. Updated the description in `services.yaml` and both strings files to state the replace-by-slot behavior.

I went with slot-based replacement rather than the index-based `update_reservation`/`delete_reservation` the issue mentions as an alternative, because it keeps the service's existing day/time-oriented signature — callers never see protocol indices.

## Tests

`TestReservationMergeSemantics` (5) — replaces in the same slot, appends to a free slot, repeated identical calls don't accumulate, unrelated entries survive, input list not mutated.

`TestSetReservationRefusesUnfetchedWrite` (2) — an empty cache triggers a fetch before the write; a failed fetch raises and calls `async_update_reservations` **not at all**.

I verified the refusal tests genuinely catch the bug by restoring the warn-and-proceed code — both fail, then pass once the fix is back.

Two existing tests encoded the old behavior (empty cache, expect the write to proceed). They now use `{"reservation": []}` to mean a fetched-but-empty schedule, which is the case they were actually trying to exercise.

## Verification

220 tests pass (up from 213), ruff clean, HACS validation passes, mypy unchanged at 11 pre-existing errors.