### PR TITLE
feat: Expose programmed reservation and TOU schedules as entity state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,29 @@
 
 ## [Unreleased]
 
+### Added
+- **Programmed schedules readable as entity state**: the reservation and TOU
+  schedules were only reachable as in-process coordinator dicts and one-shot
+  `nwp500_reservations_updated` / `nwp500_tou_updated` bus events, so an
+  external scheduler had to run a WebSocket request/event dance and could not
+  poll them like normal state. Adds two diagnostic sensors per device,
+  **Reservation Schedule** and **TOU Schedule**, whose state is the number of
+  programmed entries and whose attributes carry the program itself:
+  - `entries` — the raw entries as the device reports them
+  - `enabled` — whether the schedule system is switched on at the device
+  - `schedule_hash` — a stable, order-independent hash of the program, so a
+    consumer can check desired-vs-programmed with one comparison instead of
+    diffing entries. Mirrors `ReservationSchedule.canonical()` in
+    nwp500-python.
+
+  The state is `None` until the schedule has been read, keeping "not fetched
+  yet" distinct from "device has no entries". The schedules are also
+  re-requested every `SCHEDULE_REFRESH_CYCLES` (40) coordinator updates —
+  roughly every 20 minutes at the default interval — so the exposed state
+  reflects changes made outside Home Assistant, in addition to the existing
+  refresh after each write. Implements
+  [issue #103](https://github.com/eman/ha_nwp500/issues/103).
+
 ### Fixed
 - **Reservation and vacation service documentation corrected**: three
   descriptions contradicted the code or the library. The `update_reservations`

--- a/custom_components/nwp500/const.py
+++ b/custom_components/nwp500/const.py
@@ -61,6 +61,12 @@ SLOW_UPDATE_THRESHOLD: Final = (
     15.0  # seconds - warn if update takes longer than this
 )
 
+# How many coordinator update cycles between re-reads of the programmed
+# reservation/TOU schedules. They change rarely and only on request, so this
+# is deliberately slower than the device-info fallback (every 10th cycle):
+# at the default 30s interval this is roughly every 20 minutes.
+SCHEDULE_REFRESH_CYCLES: Final = 40
+
 # Reconnection backoff parameters
 # Exponential backoff delays (seconds) for MQTT reconnection attempts
 RECONNECT_BACKOFF_DELAYS: Final = [2.0, 5.0, 15.0, 30.0, 60.0]

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -1069,7 +1069,11 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         ):
             try:
                 await request(mac_address)
-            except (RuntimeError, OSError, MqttError) as err:
+            except (TimeoutError, RuntimeError, OSError, MqttError) as err:
+                # TimeoutError is caught deliberately: the caller's own
+                # handler treats it as a failed *status* request and starts
+                # counting toward a forced reconnect, so a slow schedule
+                # re-read must not be mistaken for a dead connection.
                 _LOGGER.debug(
                     "Periodic %s refresh failed for %s: %s",
                     label,

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -30,6 +30,7 @@ from .const import (
     DEFAULT_SCAN_INTERVAL,
     DOMAIN,
     MIN_RECONNECT_INTERVAL,
+    SCHEDULE_REFRESH_CYCLES,
     SLOW_UPDATE_THRESHOLD,
 )
 from .mqtt_manager import NWP500MqttManager
@@ -87,6 +88,11 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         self._device_info_request_counter: dict[
             str, int
         ] = {}  # Track fallback device info requests
+        # Track periodic schedule re-reads. The device only reports its
+        # reservation/TOU program when asked, so without this the exposed
+        # schedule state would go stale after any change made outside Home
+        # Assistant (the app, the front panel).
+        self._schedule_request_counter: dict[str, int] = {}
 
         # Performance tracking
         self._update_count: int = 0
@@ -399,6 +405,20 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                                     "for %s",
                                     mac_address,
                                 )
+
+                        # Periodically re-read the programmed schedules so
+                        # the exposed entity state reflects changes made
+                        # outside Home Assistant (the vendor app, the front
+                        # panel). The device only reports them when asked.
+                        schedule_counter = (
+                            self._schedule_request_counter.get(mac_address, 0)
+                            + 1
+                        ) % SCHEDULE_REFRESH_CYCLES
+                        self._schedule_request_counter[mac_address] = (
+                            schedule_counter
+                        )
+                        if schedule_counter == 0:
+                            await self._async_refresh_schedules(mac_address)
 
                     except TimeoutError, MqttError:
                         self._consecutive_timeouts += 1
@@ -1034,6 +1054,28 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         return await self.mqtt_manager.send_command(
             device, "request_reservations"
         )
+
+    async def _async_refresh_schedules(self, mac_address: str) -> None:
+        """Re-read the programmed reservation and TOU schedules.
+
+        Fire-and-forget: the responses land in `reservation_schedules` /
+        `tou_schedules` through the MQTT callbacks, which is what the
+        schedule sensors read. Failures are logged and ignored so a schedule
+        refresh never breaks the status update cycle.
+        """
+        for label, request in (
+            ("reservations", self.async_request_reservations),
+            ("TOU settings", self.async_request_tou_settings),
+        ):
+            try:
+                await request(mac_address)
+            except (RuntimeError, OSError, MqttError) as err:
+                _LOGGER.debug(
+                    "Periodic %s refresh failed for %s: %s",
+                    label,
+                    mac_address,
+                    err,
+                )
 
     async def async_fetch_reservations(
         self, mac_address: str, timeout: float = 10.0

--- a/custom_components/nwp500/schedule_state.py
+++ b/custom_components/nwp500/schedule_state.py
@@ -1,0 +1,91 @@
+"""Canonical representations of the programmed schedules.
+
+An external scheduler that programs the device needs to check what is
+currently programmed without diffing entry lists by hand. These helpers
+reduce a schedule to a stable, order-independent form and hash it, so a
+consumer can compare a desired program against the device read-back with a
+single string equality.
+
+The canonical form mirrors `ReservationSchedule.canonical()` /
+`TOUReservationSchedule.canonical()` in nwp500-python: `(enabled, sorted
+tuple of raw protocol field tuples)`. It is computed here from the raw
+dicts the coordinator stores, which are `model_dump()` output rather than
+model instances.
+"""
+
+import hashlib
+import json
+from typing import Any
+
+# Raw protocol fields per entry, in the order the library's canonical_key()
+# uses. Keeping the order identical keeps the two representations aligned.
+_RESERVATION_FIELDS = ("enable", "week", "hour", "min", "mode", "param")
+_TOU_FIELDS = (
+    "season",
+    "week",
+    "start_hour",
+    "start_min",
+    "end_hour",
+    "end_min",
+    "price_min",
+    "price_max",
+    "decimal_point",
+)
+
+# Device bool convention: 2 = on, 1 = off.
+_DEVICE_BOOL_ON = 2
+
+
+def _entry_key(
+    entry: dict[str, Any], fields: tuple[str, ...]
+) -> tuple[int, ...]:
+    """Reduce one entry to its raw protocol fields."""
+    return tuple(int(entry.get(field, 0) or 0) for field in fields)
+
+
+def _canonical(
+    schedule: dict[str, Any], fields: tuple[str, ...]
+) -> tuple[bool, tuple[tuple[int, ...], ...]]:
+    """Return `(enabled, sorted entry keys)` for a stored schedule."""
+    enabled = schedule.get("reservation_use") == _DEVICE_BOOL_ON
+    entries = schedule.get("reservation") or []
+    keys = sorted(_entry_key(entry, fields) for entry in entries)
+    return enabled, tuple(keys)
+
+
+def reservation_canonical(
+    schedule: dict[str, Any],
+) -> tuple[bool, tuple[tuple[int, ...], ...]]:
+    """Canonical form of a reservation schedule."""
+    return _canonical(schedule, _RESERVATION_FIELDS)
+
+
+def tou_canonical(
+    schedule: dict[str, Any],
+) -> tuple[bool, tuple[tuple[int, ...], ...]]:
+    """Canonical form of a TOU schedule."""
+    return _canonical(schedule, _TOU_FIELDS)
+
+
+def schedule_hash(
+    canonical: tuple[bool, tuple[tuple[int, ...], ...]],
+) -> str:
+    """Hash a canonical schedule into a short, stable identifier.
+
+    Two schedules with the same entries hash the same regardless of the
+    order the device reported them in, so a consumer can check whether what
+    it wants is already programmed without comparing entry by entry.
+    """
+    payload = json.dumps(canonical, separators=(",", ":"), sort_keys=True)
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:16]
+
+
+def reservation_entries(schedule: dict[str, Any]) -> list[dict[str, Any]]:
+    """Return the raw reservation/TOU entries from a stored schedule."""
+    entries = schedule.get("reservation") or []
+    return [dict(entry) for entry in entries]
+
+
+def is_enabled(schedule: dict[str, Any]) -> bool:
+    """Whether the schedule system is switched on at the device."""
+    return schedule.get("reservation_use") == _DEVICE_BOOL_ON

--- a/custom_components/nwp500/schedule_state.py
+++ b/custom_components/nwp500/schedule_state.py
@@ -13,6 +13,7 @@ dicts the coordinator stores, which are `model_dump()` output rather than
 model instances.
 """
 
+import copy
 import hashlib
 import json
 from typing import Any
@@ -81,9 +82,14 @@ def schedule_hash(
 
 
 def reservation_entries(schedule: dict[str, Any]) -> list[dict[str, Any]]:
-    """Return the raw reservation/TOU entries from a stored schedule."""
+    """Return the raw reservation/TOU entries from a stored schedule.
+
+    Deep-copied: `model_dump()` includes computed fields such as the `days`
+    list, so a shallow copy would still share those nested objects with the
+    coordinator's stored schedule and let an attribute reader corrupt it.
+    """
     entries = schedule.get("reservation") or []
-    return [dict(entry) for entry in entries]
+    return [copy.deepcopy(entry) for entry in entries]
 
 
 def is_enabled(schedule: dict[str, Any]) -> bool:

--- a/custom_components/nwp500/sensor.py
+++ b/custom_components/nwp500/sensor.py
@@ -23,6 +23,7 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
+from . import schedule_state
 from .const import DOMAIN, SENSOR_CONFIGS
 from .coordinator import NWP500DataUpdateCoordinator
 from .entity import NWP500Entity
@@ -196,6 +197,13 @@ async def async_setup_entry(
             entities.append(
                 NWP500Sensor(coordinator, mac_address, device, description)
             )
+        # Programmed schedules, readable per device
+        entities.append(
+            NWP500ReservationScheduleSensor(coordinator, mac_address, device)
+        )
+        entities.append(
+            NWP500TOUScheduleSensor(coordinator, mac_address, device)
+        )
 
     # Add diagnostic telemetry sensors (one per integration, not per device)
     if coordinator.data:
@@ -466,3 +474,104 @@ class NWP500ConsecutiveTimeoutsSensor(NWP500DiagnosticSensor):
         """Return the number of consecutive timeouts."""
         telemetry = self.coordinator.get_mqtt_telemetry()
         return int(telemetry.get("consecutive_timeouts", 0))
+
+
+class NWP500ScheduleSensor(NWP500DiagnosticSensor):
+    """Exposes a programmed schedule as readable entity state.
+
+    The reservation and TOU schedules were previously reachable only as
+    coordinator dicts and one-shot bus events, so an external scheduler had
+    to run a WebSocket request/event dance and could not simply poll. The
+    state is the entry count and the program itself is in the attributes,
+    including a canonical hash for cheap desired-vs-programmed comparison.
+    """
+
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        coordinator: NWP500DataUpdateCoordinator,
+        mac_address: str,
+        device: Device,
+        key: str,
+        store: str,
+        canonical_fn: Callable[[dict[str, Any]], Any],
+    ) -> None:
+        """Initialize the schedule sensor."""
+        super().__init__(coordinator, mac_address, device, key)
+        self._store = store
+        self._canonical_fn = canonical_fn
+
+    def _schedule(self) -> dict[str, Any] | None:
+        """Return the stored schedule, or None if never fetched."""
+        store: dict[str, dict[str, Any]] = getattr(
+            self.coordinator, self._store
+        )
+        return store.get(self.mac_address)
+
+    @property
+    def native_value(self) -> int | None:  # type: ignore[reportIncompatibleVariableOverride,unused-ignore]
+        """Return the number of programmed entries.
+
+        None until the schedule has been read, so "not fetched yet" stays
+        distinguishable from "device has no entries".
+        """
+        schedule = self._schedule()
+        if schedule is None:
+            return None
+        return len(schedule_state.reservation_entries(schedule))
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:  # type: ignore[reportIncompatibleVariableOverride,unused-ignore]
+        """Return the programmed entries and a hash of the program."""
+        schedule = self._schedule()
+        if schedule is None:
+            return {"entries": [], "enabled": None, "schedule_hash": None}
+
+        return {
+            "entries": schedule_state.reservation_entries(schedule),
+            "enabled": schedule_state.is_enabled(schedule),
+            "schedule_hash": schedule_state.schedule_hash(
+                self._canonical_fn(schedule)
+            ),
+        }
+
+
+class NWP500ReservationScheduleSensor(NWP500ScheduleSensor):
+    """The programmed reservation schedule."""
+
+    def __init__(
+        self,
+        coordinator: NWP500DataUpdateCoordinator,
+        mac_address: str,
+        device: Device,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            mac_address,
+            device,
+            "reservation_schedule",
+            "reservation_schedules",
+            schedule_state.reservation_canonical,
+        )
+
+
+class NWP500TOUScheduleSensor(NWP500ScheduleSensor):
+    """The programmed Time of Use schedule."""
+
+    def __init__(
+        self,
+        coordinator: NWP500DataUpdateCoordinator,
+        mac_address: str,
+        device: Device,
+    ) -> None:
+        """Initialize the sensor."""
+        super().__init__(
+            coordinator,
+            mac_address,
+            device,
+            "tou_schedule",
+            "tou_schedules",
+            schedule_state.tou_canonical,
+        )

--- a/custom_components/nwp500/sensor.py
+++ b/custom_components/nwp500/sensor.py
@@ -484,9 +484,10 @@ class NWP500ScheduleSensor(NWP500DiagnosticSensor):
     to run a WebSocket request/event dance and could not simply poll. The
     state is the entry count and the program itself is in the attributes,
     including a canonical hash for cheap desired-vs-programmed comparison.
-    """
 
-    _attr_state_class = SensorStateClass.MEASUREMENT
+    No state_class: the entry count is a unitless configuration value, not a
+    measurement, and long-term statistics over it would be meaningless.
+    """
 
     def __init__(
         self,

--- a/custom_components/nwp500/strings.json
+++ b/custom_components/nwp500/strings.json
@@ -329,6 +329,12 @@
       },
       "consecutive_timeouts": {
         "name": "Consecutive Timeouts"
+      },
+      "reservation_schedule": {
+        "name": "Reservation Schedule"
+      },
+      "tou_schedule": {
+        "name": "TOU Schedule"
       }
     },
     "binary_sensor": {

--- a/custom_components/nwp500/translations/en.json
+++ b/custom_components/nwp500/translations/en.json
@@ -329,6 +329,12 @@
       },
       "consecutive_timeouts": {
         "name": "Consecutive Timeouts"
+      },
+      "reservation_schedule": {
+        "name": "Reservation Schedule"
+      },
+      "tou_schedule": {
+        "name": "TOU Schedule"
       }
     },
     "binary_sensor": {

--- a/tests/unit/test_schedule_state.py
+++ b/tests/unit/test_schedule_state.py
@@ -172,3 +172,16 @@ class TestEntries:
 
     def test_missing_key_yields_empty_list(self):
         assert schedule_state.reservation_entries({}) == []
+
+    def test_deep_copies_nested_values(self):
+        """model_dump() adds a computed `days` list, which must not alias.
+
+        A shallow copy would hand callers the coordinator's own list.
+        """
+        original = _entry() | {"days": ["Monday", "Wednesday"]}
+        schedule = {"reservation": [original]}
+
+        returned = schedule_state.reservation_entries(schedule)
+        returned[0]["days"].append("Sunday")
+
+        assert original["days"] == ["Monday", "Wednesday"]

--- a/tests/unit/test_schedule_state.py
+++ b/tests/unit/test_schedule_state.py
@@ -1,0 +1,174 @@
+"""Tests for the canonical schedule representation (issue #103)."""
+
+from __future__ import annotations
+
+from custom_components.nwp500 import schedule_state
+
+
+def _entry(**overrides):
+    entry = {
+        "enable": 2,
+        "week": 42,
+        "hour": 6,
+        "min": 30,
+        "mode": 3,
+        "param": 120,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _tou_period(**overrides):
+    period = {
+        "season": 4095,
+        "week": 254,
+        "start_hour": 0,
+        "start_min": 0,
+        "end_hour": 6,
+        "end_min": 0,
+        "price_min": 10,
+        "price_max": 20,
+        "decimal_point": 2,
+    }
+    period.update(overrides)
+    return period
+
+
+class TestEnabledFlag:
+    """`reservation_use` follows the device bool convention: 2=on, 1=off."""
+
+    def test_two_means_enabled(self):
+        assert schedule_state.is_enabled({"reservation_use": 2}) is True
+
+    def test_one_means_disabled(self):
+        assert schedule_state.is_enabled({"reservation_use": 1}) is False
+
+    def test_missing_means_disabled(self):
+        assert schedule_state.is_enabled({}) is False
+
+
+class TestCanonicalForm:
+    """The canonical form must not depend on the order entries arrive in."""
+
+    def test_order_independent(self):
+        a = {
+            "reservation_use": 2,
+            "reservation": [_entry(hour=6), _entry(hour=18)],
+        }
+        b = {
+            "reservation_use": 2,
+            "reservation": [_entry(hour=18), _entry(hour=6)],
+        }
+
+        assert schedule_state.reservation_canonical(
+            a
+        ) == schedule_state.reservation_canonical(b)
+
+    def test_distinguishes_different_entries(self):
+        a = {"reservation_use": 2, "reservation": [_entry(mode=3)]}
+        b = {"reservation_use": 2, "reservation": [_entry(mode=4)]}
+
+        assert schedule_state.reservation_canonical(
+            a
+        ) != schedule_state.reservation_canonical(b)
+
+    def test_distinguishes_enabled_state(self):
+        a = {"reservation_use": 2, "reservation": [_entry()]}
+        b = {"reservation_use": 1, "reservation": [_entry()]}
+
+        assert schedule_state.reservation_canonical(
+            a
+        ) != schedule_state.reservation_canonical(b)
+
+    def test_ignores_computed_fields(self):
+        """model_dump() includes computed fields; only raw ones count."""
+        plain = {"reservation_use": 2, "reservation": [_entry()]}
+        with_computed = {
+            "reservation_use": 2,
+            "reservation": [
+                _entry() | {"enabled": True, "days": ["Monday"]},
+            ],
+        }
+
+        assert schedule_state.reservation_canonical(
+            plain
+        ) == schedule_state.reservation_canonical(with_computed)
+
+    def test_empty_schedule(self):
+        assert schedule_state.reservation_canonical({}) == (False, ())
+
+    def test_tou_uses_its_own_field_set(self):
+        """TOU entries carry season/price fields reservations do not."""
+        a = {"reservation_use": 2, "reservation": [_tou_period(price_max=20)]}
+        b = {"reservation_use": 2, "reservation": [_tou_period(price_max=99)]}
+
+        assert schedule_state.tou_canonical(a) != schedule_state.tou_canonical(
+            b
+        )
+
+
+class TestScheduleHash:
+    """The hash is what a consumer compares to check it is in sync."""
+
+    def test_same_program_same_hash_regardless_of_order(self):
+        a = {
+            "reservation_use": 2,
+            "reservation": [_entry(hour=6), _entry(hour=18)],
+        }
+        b = {
+            "reservation_use": 2,
+            "reservation": [_entry(hour=18), _entry(hour=6)],
+        }
+
+        assert schedule_state.schedule_hash(
+            schedule_state.reservation_canonical(a)
+        ) == schedule_state.schedule_hash(
+            schedule_state.reservation_canonical(b)
+        )
+
+    def test_different_program_different_hash(self):
+        a = {"reservation_use": 2, "reservation": [_entry(hour=6)]}
+        b = {"reservation_use": 2, "reservation": [_entry(hour=7)]}
+
+        assert schedule_state.schedule_hash(
+            schedule_state.reservation_canonical(a)
+        ) != schedule_state.schedule_hash(
+            schedule_state.reservation_canonical(b)
+        )
+
+    def test_is_stable_across_calls(self):
+        schedule = {"reservation_use": 2, "reservation": [_entry()]}
+        canonical = schedule_state.reservation_canonical(schedule)
+
+        assert schedule_state.schedule_hash(
+            canonical
+        ) == schedule_state.schedule_hash(canonical)
+
+    def test_is_a_short_hex_string(self):
+        digest = schedule_state.schedule_hash(
+            schedule_state.reservation_canonical({})
+        )
+
+        assert len(digest) == 16
+        assert all(c in "0123456789abcdef" for c in digest)
+
+
+class TestEntries:
+    """Entries are copied out so callers cannot mutate coordinator state."""
+
+    def test_returns_the_entries(self):
+        schedule = {"reservation": [_entry(hour=6), _entry(hour=18)]}
+
+        assert len(schedule_state.reservation_entries(schedule)) == 2
+
+    def test_copies_each_entry(self):
+        original = _entry()
+        schedule = {"reservation": [original]}
+
+        returned = schedule_state.reservation_entries(schedule)
+        returned[0]["hour"] = 23
+
+        assert original["hour"] == 6
+
+    def test_missing_key_yields_empty_list(self):
+        assert schedule_state.reservation_entries({}) == []

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -8,7 +8,9 @@ import pytest
 from homeassistant.core import HomeAssistant
 
 from custom_components.nwp500.sensor import (
+    NWP500ReservationScheduleSensor,
     NWP500Sensor,
+    NWP500TOUScheduleSensor,
     async_setup_entry,
 )
 
@@ -485,3 +487,160 @@ class TestNWP500Sensor:
         sensor = NWP500Sensor(mock_coordinator, mac_address, mock_device, desc)
 
         assert sensor.native_value is None
+
+
+class TestScheduleSensors:
+    """The programmed schedules are exposed as pollable entity state.
+
+    Before issue #103 they lived only in coordinator dicts and one-shot bus
+    events, so an external scheduler could not read back what is programmed
+    over the REST API.
+    """
+
+    @staticmethod
+    def _entry(**overrides):
+        entry = {
+            "enable": 2,
+            "week": 42,
+            "hour": 6,
+            "min": 30,
+            "mode": 3,
+            "param": 120,
+        }
+        entry.update(overrides)
+        return entry
+
+    def _sensor(self, mock_coordinator, mock_device, schedule, cls):
+        mock_coordinator.reservation_schedules = {}
+        mock_coordinator.tou_schedules = {}
+        if schedule is not None:
+            store = (
+                "reservation_schedules"
+                if cls is NWP500ReservationScheduleSensor
+                else "tou_schedules"
+            )
+            getattr(mock_coordinator, store)["AA:BB:CC:DD:EE:FF"] = schedule
+        return cls(mock_coordinator, "AA:BB:CC:DD:EE:FF", mock_device)
+
+    @pytest.mark.parametrize(
+        "cls",
+        [NWP500ReservationScheduleSensor, NWP500TOUScheduleSensor],
+    )
+    def test_state_is_none_before_the_schedule_is_read(
+        self, mock_coordinator, mock_device, cls
+    ):
+        """Unfetched must stay distinguishable from "device has none"."""
+        sensor = self._sensor(mock_coordinator, mock_device, None, cls)
+
+        assert sensor.native_value is None
+        assert sensor.extra_state_attributes["enabled"] is None
+        assert sensor.extra_state_attributes["schedule_hash"] is None
+
+    @pytest.mark.parametrize(
+        "cls",
+        [NWP500ReservationScheduleSensor, NWP500TOUScheduleSensor],
+    )
+    def test_state_is_zero_when_device_has_no_entries(
+        self, mock_coordinator, mock_device, cls
+    ):
+        """A fetched but empty program reports 0, not None."""
+        sensor = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {"reservation_use": 1, "reservation": []},
+            cls,
+        )
+
+        assert sensor.native_value == 0
+        assert sensor.extra_state_attributes["enabled"] is False
+
+    def test_state_counts_entries(self, mock_coordinator, mock_device):
+        """The state is the number of programmed entries."""
+        sensor = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {
+                "reservation_use": 2,
+                "reservation": [self._entry(hour=6), self._entry(hour=18)],
+            },
+            NWP500ReservationScheduleSensor,
+        )
+
+        assert sensor.native_value == 2
+
+    def test_attributes_expose_the_program(self, mock_coordinator, mock_device):
+        """The entries themselves are readable, with the enable flag."""
+        entries = [self._entry(hour=6), self._entry(hour=18)]
+        sensor = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {"reservation_use": 2, "reservation": entries},
+            NWP500ReservationScheduleSensor,
+        )
+
+        attrs = sensor.extra_state_attributes
+
+        assert attrs["entries"] == entries
+        assert attrs["enabled"] is True
+        assert attrs["schedule_hash"]
+
+    def test_hash_is_order_independent(self, mock_coordinator, mock_device):
+        """Same program, different report order, same hash."""
+        forward = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {
+                "reservation_use": 2,
+                "reservation": [self._entry(hour=6), self._entry(hour=18)],
+            },
+            NWP500ReservationScheduleSensor,
+        )
+        first = forward.extra_state_attributes["schedule_hash"]
+
+        reversed_ = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {
+                "reservation_use": 2,
+                "reservation": [self._entry(hour=18), self._entry(hour=6)],
+            },
+            NWP500ReservationScheduleSensor,
+        )
+
+        assert reversed_.extra_state_attributes["schedule_hash"] == first
+
+    def test_hash_changes_when_the_program_changes(
+        self, mock_coordinator, mock_device
+    ):
+        """A consumer can detect drift from the desired program."""
+        before = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {"reservation_use": 2, "reservation": [self._entry(mode=3)]},
+            NWP500ReservationScheduleSensor,
+        ).extra_state_attributes["schedule_hash"]
+
+        after = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {"reservation_use": 2, "reservation": [self._entry(mode=4)]},
+            NWP500ReservationScheduleSensor,
+        ).extra_state_attributes["schedule_hash"]
+
+        assert before != after
+
+    def test_attributes_do_not_expose_coordinator_state(
+        self, mock_coordinator, mock_device
+    ):
+        """Mutating the attributes must not corrupt the stored schedule."""
+        entry = self._entry()
+        sensor = self._sensor(
+            mock_coordinator,
+            mock_device,
+            {"reservation_use": 2, "reservation": [entry]},
+            NWP500ReservationScheduleSensor,
+        )
+
+        sensor.extra_state_attributes["entries"][0]["hour"] = 23
+
+        assert entry["hour"] == 6

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -629,6 +629,20 @@ class TestScheduleSensors:
 
         assert before != after
 
+    @pytest.mark.parametrize(
+        "cls",
+        [NWP500ReservationScheduleSensor, NWP500TOUScheduleSensor],
+    )
+    def test_no_state_class(self, mock_coordinator, mock_device, cls):
+        """An entry count is unitless, so it must not be a MEASUREMENT.
+
+        Home Assistant expects MEASUREMENT sensors to carry a unit and would
+        otherwise record meaningless long-term statistics.
+        """
+        sensor = self._sensor(mock_coordinator, mock_device, None, cls)
+
+        assert sensor.state_class is None
+
     def test_attributes_do_not_expose_coordinator_state(
         self, mock_coordinator, mock_device
     ):


### PR DESCRIPTION
Implements #103.

## Problem confirmed

The programmed schedules live only in `coordinator.reservation_schedules` / `coordinator.tou_schedules` and are announced once via `nwp500_reservations_updated` / `nwp500_tou_updated` bus events. Nothing re-requests them — only `DEVICE_STATUS`/`DEVICE_INFO` are polled — and the only schedule-related entities are the disabled-by-default `program_reservation_use` / `program_reservation_type` booleans.

So an external scheduler running a program→verify loop can't just poll state over REST; it has to hold a WebSocket open and correlate a request with an event.

## What this adds

Two diagnostic sensors per device — **Reservation Schedule** and **TOU Schedule**.

**State** is the number of programmed entries, so it stays short and pollable. **Attributes** carry the program:

| Attribute | Meaning |
|---|---|
| `entries` | the raw entries exactly as the device reports them |
| `enabled` | whether the schedule system is switched on at the device (`reservation_use`, device bool 2=on/1=off) |
| `schedule_hash` | stable, order-independent hash of the program |

`native_value` is `None` until the schedule has been read, so **"not fetched yet" stays distinguishable from "device has no entries"** — the same distinction the #104 fix depends on.

### The hash (issue's item 3)

This is what makes the verify loop cheap — one string comparison instead of diffing entry lists.

`schedule_state.py` computes it from the raw stored dicts using the same canonical form as `ReservationSchedule.canonical()` in nwp500-python: `(enabled, sorted tuple of raw protocol field tuples)`. The coordinator stores `model_dump()` output rather than model instances, so the canonical form is recomputed here rather than delegated — the field lists and ordering are kept identical so the two agree. Computed fields that `model_dump()` adds (`enabled`, `days`) are ignored; only raw protocol fields count.

### Refresh (issue's item 2)

The device only reports its program when asked. The schedules are now re-requested every `SCHEDULE_REFRESH_CYCLES` (40) coordinator updates — about every 20 minutes at the default 30s interval — so the exposed state stays honest after changes made from the vendor app or the front panel. That's on top of the refresh the write services already trigger.

Deliberately slower than the device-info fallback (every 10th cycle): schedules change rarely, and each refresh is two extra MQTT round-trips. Failures are logged at debug and swallowed so a schedule re-read never disrupts the status cycle.

## Tests

**`test_schedule_state.py`** (16) — the enable convention, order-independence, that different programs differ, that computed fields are ignored, hash stability and shape, and that entries are copied rather than aliased.

**`TestScheduleSensors`** in `test_sensor.py` (9) — `None` before first read vs `0` when the device has none, entry counting, attribute contents, hash order-independence, hash changes when the program changes, and that mutating returned attributes can't corrupt coordinator state.

## Verification

262 tests pass (up from 237), ruff clean, HACS validation passes, mypy unchanged at 11 pre-existing errors. I also ran `basedpyright` directly over the configured scope: no findings in any file this PR touches.

## Note on scope

The issue's framing suggests the consumer wants read-back after writes. That path already worked (the write services call `async_request_reservations`); what was missing was a *pollable surface* and *periodic* refresh, which is what this adds.