### PR TITLE
fix: Pin awsiotsdk and explain mid-session SDK upgrades

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -25,7 +25,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
 - `nwp500-python==9.2.1` - Core library for Navien device communication
-- `awsiotsdk>=1.29.0` - AWS IoT SDK for MQTT
+- `awsiotsdk==1.31.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2026.3.0` - Home Assistant core
 - `mypy`, `basedpyright` - Type checkers
 - `pytest` and related testing tools

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 ## [Unreleased]
 
 ### Fixed
+- **MQTT failed to connect after Home Assistant upgraded the AWS SDK**:
+  `manifest.json` requested `awsiotsdk>=1.29.0`, so Home Assistant installed
+  whatever was newest. When `awsiotsdk` 1.31.0 was published (2026-07-24) it
+  was installed *during* a Home Assistant startup, seconds before the
+  integration connected. The process already held modules from the previous
+  `awscrt`, so newly imported code read attributes the old classes did not
+  define, and MQTT setup failed with:
+
+      MQTT connection failed: 'ClientTlsContext' object has no attribute
+      '_certificate_source'
+
+  The integration then silently dropped to API-only mode and stayed there
+  until Home Assistant was restarted. Pins `awsiotsdk==1.31.0`, which in turn
+  pins `awscrt==0.36.1` exactly, so the AWS SDK now only changes when this
+  integration changes it — never mid-session. No code changes were needed to
+  adopt 1.31.0; the integration does not use the `awsiotsdk` API directly.
+- **Unclear error when the AWS SDK is upgraded mid-session**: an
+  `AttributeError` raised while connecting is now reported as what it
+  actually is — a stale-module condition that only a restart clears — instead
+  of surfacing a bare attribute error with no indication of what to do.
+  Genuine connection failures keep their existing wording.
 - **Release tooling documentation pointed at a tool that cannot run**:
   `.bumpversion.cfg` declared `current_version = 0.2.2` while the published
   version was `0.16.2`, so `bump2version` computed the wrong next version and

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -212,7 +212,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            'uv pip install "nwp500-python==9.2.1" awsiotsdk>=1.29.0'
+            'uv pip install "nwp500-python==9.2.1" "awsiotsdk==1.31.0"'
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -543,7 +543,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                'uv pip install "nwp500-python==9.2.1" awsiotsdk>=1.29.0'
+                'uv pip install "nwp500-python==9.2.1" "awsiotsdk==1.31.0"'
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -19,7 +19,7 @@
   ],
   "requirements": [
     "nwp500-python==9.2.1",
-    "awsiotsdk>=1.29.0"
+    "awsiotsdk==1.31.0"
   ],
   "single_config_entry": true,
   "version": "0.17.0"

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -242,6 +242,26 @@ class NWP500MqttManager:
                         error=Exception("Connection failed")
                     )
             return bool(connected)
+        except AttributeError as err:
+            # An AttributeError here almost always means the AWS SDK was
+            # upgraded while Home Assistant was already running: the process
+            # holds modules from the old version alongside modules imported
+            # after the upgrade, so new code reads attributes the old classes
+            # do not define. Nothing in this integration can recover from that
+            # in-process -- only a restart clears the stale modules -- so say
+            # so instead of surfacing a bare AttributeError.
+            _LOGGER.error(
+                "MQTT connection failed: %s. This usually means the AWS SDK "
+                "(awscrt/awsiotsdk) was upgraded while Home Assistant was "
+                "running, leaving a mix of old and new modules in this "
+                "process. Restart Home Assistant to resolve it. If the error "
+                "persists after a restart, please report it at "
+                "https://github.com/eman/ha_nwp500/issues",
+                err,
+            )
+            if self.diagnostics:
+                await self.diagnostics.record_connection_drop(error=err)
+            return False
         except Exception as err:
             _LOGGER.warning("MQTT connection failed: %s", err)
             # Record connection failure in diagnostics

--- a/custom_components/nwp500/mqtt_manager.py
+++ b/custom_components/nwp500/mqtt_manager.py
@@ -31,6 +31,28 @@ _RECONNECT_BACKOFF_DELAYS: list[float] = [2.0, 5.0, 15.0, 30.0, 60.0]
 _RECONNECTION_FAILED_EVENT = "reconnection_failed"
 
 
+# Top-level packages of the AWS SDK the MQTT stack runs on.
+_AWS_SDK_PACKAGES = frozenset({"awscrt", "awsiot"})
+
+
+def _raised_inside_aws_sdk(err: BaseException) -> bool:
+    """Whether `err` was raised from awscrt/awsiot module code.
+
+    Used to tell an AWS SDK stale-module condition apart from an ordinary
+    bug in this integration. Walks the traceback rather than matching the
+    message, so it keeps working when a future SDK upgrade trips over a
+    different attribute than the one first seen in the wild
+    (`ClientTlsContext._certificate_source`).
+    """
+    tb = err.__traceback__
+    while tb is not None:
+        module = tb.tb_frame.f_globals.get("__name__", "")
+        if module.split(".", 1)[0] in _AWS_SDK_PACKAGES:
+            return True
+        tb = tb.tb_next
+    return False
+
+
 class NWP500MqttManager:
     """Class to manage MQTT connection and events."""
 
@@ -243,22 +265,28 @@ class NWP500MqttManager:
                     )
             return bool(connected)
         except AttributeError as err:
-            # An AttributeError here almost always means the AWS SDK was
-            # upgraded while Home Assistant was already running: the process
-            # holds modules from the old version alongside modules imported
-            # after the upgrade, so new code reads attributes the old classes
-            # do not define. Nothing in this integration can recover from that
+            # An AttributeError raised from inside awscrt/awsiot means the AWS
+            # SDK was upgraded while Home Assistant was already running: the
+            # process holds modules from the old version alongside modules
+            # imported after the upgrade, so new code reads attributes the old
+            # classes do not define. Nothing here can recover from that
             # in-process -- only a restart clears the stale modules -- so say
             # so instead of surfacing a bare AttributeError.
-            _LOGGER.error(
-                "MQTT connection failed: %s. This usually means the AWS SDK "
-                "(awscrt/awsiotsdk) was upgraded while Home Assistant was "
-                "running, leaving a mix of old and new modules in this "
-                "process. Restart Home Assistant to resolve it. If the error "
-                "persists after a restart, please report it at "
-                "https://github.com/eman/ha_nwp500/issues",
-                err,
-            )
+            #
+            # An AttributeError from our own code is an ordinary bug and must
+            # not send users off to restart, so it keeps the generic wording.
+            if _raised_inside_aws_sdk(err):
+                _LOGGER.error(
+                    "MQTT connection failed: %s. This usually means the AWS "
+                    "SDK (awscrt/awsiotsdk) was upgraded while Home Assistant "
+                    "was running, leaving a mix of old and new modules in "
+                    "this process. Restart Home Assistant to resolve it. If "
+                    "it persists after a restart, please report it at "
+                    "https://github.com/eman/ha_nwp500/issues",
+                    err,
+                )
+            else:
+                _LOGGER.warning("MQTT connection failed: %s", err)
             if self.diagnostics:
                 await self.diagnostics.record_connection_drop(error=err)
             return False

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@
 nwp500-python==9.2.1
 
 # AWS IoT SDK for MQTT communication
-awsiotsdk>=1.29.0
+awsiotsdk==1.31.0
 
 
 

--- a/tests/unit/test_mqtt_manager.py
+++ b/tests/unit/test_mqtt_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -611,3 +612,75 @@ async def test_setup_clean_session_false_without_user_seq(
 
     assert mock_mqtt_client.config is not None
     assert mock_mqtt_client.config.clean_session is False
+
+
+class TestSdkUpgradedDuringStartup:
+    """An AttributeError from connect() means stale modules, not a bad config.
+
+    Home Assistant can install a newer awscrt/awsiotsdk while it is already
+    running. The process then holds the old modules alongside ones imported
+    after the upgrade, and new code reads attributes the old classes never
+    defined -- observed in the wild as:
+
+        'ClientTlsContext' object has no attribute '_certificate_source'
+
+    Only a restart clears it, so the log has to say that rather than surface
+    a bare AttributeError.
+    """
+
+    @staticmethod
+    def _patch_failing_client(monkeypatch, error):
+        """Patch the client factory so connect() raises `error`."""
+
+        class FailingClient:
+            def __init__(self, *args, **kwargs):
+                self.is_connected = False
+                self.client_id = "test-client-id"
+                self.on = MagicMock()
+                self.off = MagicMock()
+                self.connect = AsyncMock(side_effect=error)
+                self.disconnect = AsyncMock()
+
+        diagnostics = MagicMock()
+        diagnostics.record_connection_success = AsyncMock()
+        diagnostics.record_connection_drop = AsyncMock()
+
+        monkeypatch.setattr("nwp500.NavienMqttClient", FailingClient)
+        monkeypatch.setattr(
+            "nwp500.MqttDiagnosticsCollector",
+            MagicMock(return_value=diagnostics),
+        )
+
+    @pytest.mark.asyncio
+    async def test_reports_restart_guidance(self, manager, monkeypatch, caplog):
+        """The real-world failure is logged with an actionable message."""
+        self._patch_failing_client(
+            monkeypatch,
+            AttributeError(
+                "'ClientTlsContext' object has no attribute "
+                "'_certificate_source'"
+            ),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            connected = await manager.setup()
+
+        assert connected is False
+        assert "Restart Home Assistant" in caplog.text
+        assert "awscrt/awsiotsdk" in caplog.text
+        # The underlying error is still reported, not swallowed
+        assert "_certificate_source" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_other_failures_keep_the_plain_warning(
+        self, manager, monkeypatch, caplog
+    ):
+        """A normal connection failure must not blame the SDK version."""
+        self._patch_failing_client(monkeypatch, RuntimeError("network down"))
+
+        with caplog.at_level(logging.WARNING):
+            connected = await manager.setup()
+
+        assert connected is False
+        assert "network down" in caplog.text
+        assert "Restart Home Assistant" not in caplog.text

--- a/tests/unit/test_mqtt_manager.py
+++ b/tests/unit/test_mqtt_manager.py
@@ -614,8 +614,24 @@ async def test_setup_clean_session_false_without_user_seq(
     assert mock_mqtt_client.config.clean_session is False
 
 
+def _error_from_module(module_name, exc):
+    """Return `exc` carrying a traceback raised from `module_name`.
+
+    The manager distinguishes an AWS SDK stale-module condition from an
+    ordinary bug by where the exception came from, so tests need a
+    realistic traceback rather than a bare exception object.
+    """
+    namespace = {"__name__": module_name, "_exc": exc}
+    exec("def _raise():\n    raise _exc", namespace)  # noqa: S102
+    try:
+        namespace["_raise"]()
+    except type(exc) as raised:
+        return raised
+    raise AssertionError("expected the exception to be raised")
+
+
 class TestSdkUpgradedDuringStartup:
-    """An AttributeError from connect() means stale modules, not a bad config.
+    """An AttributeError from awscrt means stale modules, not a bad config.
 
     Home Assistant can install a newer awscrt/awsiotsdk while it is already
     running. The process then holds the old modules alongside ones imported
@@ -656,9 +672,12 @@ class TestSdkUpgradedDuringStartup:
         """The real-world failure is logged with an actionable message."""
         self._patch_failing_client(
             monkeypatch,
-            AttributeError(
-                "'ClientTlsContext' object has no attribute "
-                "'_certificate_source'"
+            _error_from_module(
+                "awscrt.aws_iot_metrics",
+                AttributeError(
+                    "'ClientTlsContext' object has no attribute "
+                    "'_certificate_source'"
+                ),
             ),
         )
 
@@ -670,6 +689,50 @@ class TestSdkUpgradedDuringStartup:
         assert "awscrt/awsiotsdk" in caplog.text
         # The underlying error is still reported, not swallowed
         assert "_certificate_source" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_detects_a_different_sdk_attribute(
+        self, manager, monkeypatch, caplog
+    ):
+        """Detection is by origin, so a future SDK break is covered too."""
+        self._patch_failing_client(
+            monkeypatch,
+            _error_from_module(
+                "awsiot.mqtt_connection_builder",
+                AttributeError(
+                    "'Foo' object has no attribute '_something_new'"
+                ),
+            ),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            connected = await manager.setup()
+
+        assert connected is False
+        assert "Restart Home Assistant" in caplog.text
+
+    @pytest.mark.asyncio
+    async def test_our_own_attribute_error_is_not_blamed_on_the_sdk(
+        self, manager, monkeypatch, caplog
+    ):
+        """An AttributeError from our code is a bug, not a stale module.
+
+        Telling users to restart would send them chasing the wrong thing.
+        """
+        self._patch_failing_client(
+            monkeypatch,
+            _error_from_module(
+                "custom_components.nwp500.mqtt_manager",
+                AttributeError("'NoneType' object has no attribute 'connect'"),
+            ),
+        )
+
+        with caplog.at_level(logging.DEBUG):
+            connected = await manager.setup()
+
+        assert connected is False
+        assert "'NoneType' object has no attribute 'connect'" in caplog.text
+        assert "Restart Home Assistant" not in caplog.text
 
     @pytest.mark.asyncio
     async def test_other_failures_keep_the_plain_warning(

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
     pytest-homeassistant-custom-component>=0.13.323
     pytest-timeout>=2.1.0
 commands_pre =
-    python -m pip install awsiotsdk>=1.29.0
+    python -m pip install awsiotsdk==1.31.0
     python -m pip install "nwp500-python==9.2.1" --no-deps
 
 [testenv:py314]
@@ -63,7 +63,7 @@ description = Generate HTML coverage report
 deps =
     {[testenv]deps}
 commands_pre =
-    python -m pip install awsiotsdk>=1.29.0
+    python -m pip install awsiotsdk==1.31.0
     python -m pip install "nwp500-python==9.2.1" --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \


### PR DESCRIPTION
Fixes the MQTT failure reported against v0.17.0.

## Root cause: the AWS SDK was upgraded mid-startup

`manifest.json` requested `awsiotsdk>=1.29.0`, so Home Assistant installed whatever was newest. `awsiotsdk` 1.31.0 was published **2026-07-24**; it was installed *during* a Home Assistant startup, seconds before the integration connected. The file timestamps in the affected container are conclusive:

| Event | Time |
|---|---|
| `awscrt` 0.36.1 written to `site-packages` | `21:55:17.633` |
| `Connecting to AWS IoT endpoint` | `21:55:20.011` |
| `'ClientTlsContext' object has no attribute '_certificate_source'` | `21:55:20.031` |

The process still held the **previous** `awscrt`'s modules. `awscrt`'s newer `aws_iot_metrics` reads:

```python
val = _certificate_source_metrics_value(client_options.tls_ctx._certificate_source)
```

...against a `ClientTlsContext` whose `__slots__` predated that attribute. Old object, new reader, one process.

**Nothing in v0.17.0's code was at fault.** That's also why it didn't reproduce: the versions on disk are self-consistent 0.36.1, and building the identical connection in the same container succeeds and reaches DNS.

The integration then dropped to API-only mode with no retry and stayed degraded until a restart.

## Fix 1 — pin the SDK

`awsiotsdk==1.31.0` in `manifest.json`, `requirements.txt`, `tox.ini` and the devcontainer docs.

`awsiotsdk` pins `awscrt==0.36.1` **exactly** (verified: `requires ['awscrt==0.36.1']`), so pinning the one determines both. The AWS SDK now only moves when this repo moves it — never mid-session. Exact pins are also what HA core integrations do.

**Adopting 1.31.0 required no code changes.** The integration never calls the `awsiotsdk` API — it reaches it only through `nwp500-python` — and its sole direct AWS import is `AwsCrtError` in `coordinator.py:10`. 1.31.0 is already the version running successfully.

## Fix 2 — make the failure self-explanatory

`AttributeError` is now handled separately from the generic connect handler. Nothing can recover from mixed modules in-process, so the log names the cause and says to restart instead of surfacing a bare attribute error. Ordinary failures keep the existing warning.

## Tests

`TestSdkUpgradedDuringStartup` — the real-world `_certificate_source` error produces restart guidance while still reporting the underlying error, and a plain `RuntimeError("network down")` does **not** get blamed on the SDK version.

## Verified against real hardware

Not just unit tests this time. In the Home Assistant container, after a restart on this same build:

```
22:03:56 [nwp500.mqtt.connection] Connected successfully: session_present=False
```

Zero `_certificate_source` errors, MQTT publishing and receiving, and the v0.17.0 schedule sensor reporting live device data:

```
sensor.san_rafael_nwp500_reservation_schedule = 1
   enabled: False   hash: 46c63daa84ef7be5   entries: 1
```

267 tests pass, ruff clean, HACS validation passes, mypy unchanged at 11 pre-existing errors.