### PR TITLE
feat: Adopt nwp500-python 9.3.0

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -24,7 +24,7 @@ This directory contains the configuration for developing the Navien NWP500 Home 
 
 ### Python Packages
 All packages from `requirements.txt` are pre-installed:
-- `nwp500-python==9.2.1` - Core library for Navien device communication
+- `nwp500-python==9.3.0` - Core library for Navien device communication
 - `awsiotsdk==1.31.0` - AWS IoT SDK for MQTT
 - `homeassistant>=2026.3.0` - Home Assistant core
 - `mypy`, `basedpyright` - Type checkers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,40 @@
 
 ## [Unreleased]
 
+### Changed
+- **Upgraded `nwp500-python` from 9.2.1 to 9.3.0**, which corrected a unit-scale
+  error in the tank energy fields and renamed them to match what they actually
+  measure. Both old fields were removed outright rather than aliased, so the
+  entities built on them are replaced:
+
+  | Removed entity | Replacement | Meaning |
+  | --- | --- | --- |
+  | Total Energy Capacity | Full Recovery Energy | Energy to recover a fully depleted tank to the current setpoint |
+  | Available Energy Capacity | Energy to Setpoint | Energy needed to bring the tank from its current temperature up to the setpoint |
+  | — | Usable Energy *(new, enabled by default)* | Energy drawable from the tank as useful hot water |
+
+  **Reported values are now 2.5x smaller.** The previous numbers were wrong, not
+  the new ones. Any history, statistics, or energy dashboard configuration built
+  on the old entities is off by that factor; rescale it by 0.4 or discard it.
+
+  Only Usable Energy behaves like a state of charge. The other two are both
+  measured from the setpoint, so they move when the setpoint moves even though
+  the water in the tank does not — which is why the `energy_storage` device class
+  now applies to Usable Energy alone. Full Recovery Energy and Energy to Setpoint
+  remain disabled by default.
+- **Eight status flags can now report `Unknown` instead of `Off`**: `Operation
+  Busy`, `Compressor Running`, `Anti-Legionella Enabled`, `Anti-Legionella Cycle
+  Running`, `Upper Electric Heating Element`, `Lower Electric Heating Element`,
+  `Air Filter Alarm Enabled`, and `Recirculation Reservation Active`. The device
+  encodes these as unknown/off/on, and the library previously collapsed unknown
+  to off. Automations that treat these as strictly on/off should account for the
+  unknown state.
+
+### Fixed
+- **Stale energy entities are removed on upgrade**: the two entities whose
+  backing device fields no longer exist are deleted from the entity registry at
+  setup instead of lingering as permanently unavailable.
+
 ## [0.17.1] - 2026-07-30
 
 ### Fixed

--- a/custom_components/nwp500/__init__.py
+++ b/custom_components/nwp500/__init__.py
@@ -5,7 +5,7 @@ Requires Home Assistant 2026.3+ (Python 3.14).
 
 import logging
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import voluptuous as vol
 from homeassistant.components.frontend import add_extra_js_url
@@ -754,9 +754,42 @@ async def async_setup(hass: HomeAssistant, config: dict) -> bool:
     return True
 
 
+# Sensor keys dropped in nwp500-python 9.3.0. The library removed the
+# underlying DeviceStatus fields outright rather than aliasing them, so these
+# entities can never produce a value again. Left in place they would sit in the
+# registry as permanently unavailable with no indication why — and their
+# recorded history is wrong regardless, having been captured at a unit scale
+# that was 2.5x too large.
+_REMOVED_SENSOR_KEYS: Final = (
+    "total_energy_capacity",
+    "available_energy_capacity",
+)
+
+
+def _async_remove_stale_energy_entities(
+    hass: HomeAssistant, entry: ConfigEntry
+) -> None:
+    """Remove energy sensors whose backing library fields no longer exist."""
+    entity_registry = er.async_get(hass)
+    suffixes = tuple(f"_{key}" for key in _REMOVED_SENSOR_KEYS)
+
+    for entity_entry in er.async_entries_for_config_entry(
+        entity_registry, entry.entry_id
+    ):
+        if entity_entry.unique_id.endswith(suffixes):
+            _LOGGER.info(
+                "Removing %s: its device field was removed in "
+                "nwp500-python 9.3.0",
+                entity_entry.entity_id,
+            )
+            entity_registry.async_remove(entity_entry.entity_id)
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up NWP500 from a config entry."""
     hass.data.setdefault(DOMAIN, {})
+
+    _async_remove_stale_energy_entities(hass, entry)
 
     # Unit system is determined by the coordinator from the HA configuration
     # and passed into NavienAuthClient/NavienAPIClient/MQTT. No unit handling

--- a/custom_components/nwp500/config_flow.py
+++ b/custom_components/nwp500/config_flow.py
@@ -212,7 +212,7 @@ async def validate_input(
     if not nwp500_available:
         _LOGGER.error(
             "nwp500-python library not installed. Please install with: "
-            'uv pip install "nwp500-python==9.2.1" "awsiotsdk==1.31.0"'
+            'uv pip install "nwp500-python==9.3.0" "awsiotsdk==1.31.0"'
         )
         raise CannotConnect("nwp500-python library not available")
 

--- a/custom_components/nwp500/const.py
+++ b/custom_components/nwp500/const.py
@@ -371,15 +371,21 @@ DEVICE_STATUS_SENSORS: Final = {
         "state_class": "total_increasing",
         "entity_registry_enabled_default": False,
     },
-    "total_energy_capacity": {
-        "name": "Total Energy Capacity",
-        "device_class": "energy",
+    "usable_energy": {
+        "name": "Usable Energy",
+        "device_class": "energy_storage",
+        "unit": "Wh",
+        "entity_registry_enabled_default": True,
+    },
+    "energy_to_setpoint": {
+        "name": "Energy to Setpoint",
+        "device_class": None,
         "unit": "Wh",
         "entity_registry_enabled_default": False,
     },
-    "available_energy_capacity": {
-        "name": "Available Energy Capacity",
-        "device_class": "energy",
+    "full_recovery_energy": {
+        "name": "Full Recovery Energy",
+        "device_class": None,
         "unit": "Wh",
         "entity_registry_enabled_default": False,
     },
@@ -621,20 +627,35 @@ SENSOR_CONFIGS: Final = {
         "state_class": "measurement",
         "enabled": True,
     },
-    "total_energy_capacity": {
-        "attr": "total_energy_capacity",
-        "name": "Total Energy Capacity",
+    # Energy drawable from the tank as useful hot water. This is the only one
+    # of the three that behaves like a state of charge: the other two are both
+    # measured from the setpoint, so they move when the setpoint moves even
+    # though the water in the tank does not.
+    "usable_energy": {
+        "attr": "usable_energy",
+        "name": "Usable Energy",
         "device_class": "energy_storage",
         "unit": "Wh",
         "state_class": "measurement",
+        "enabled": True,
+    },
+    # Energy needed to bring the tank from its current temperature up to the
+    # setpoint. No device_class: a deficit is not stored energy.
+    "energy_to_setpoint": {
+        "attr": "energy_to_setpoint",
+        "name": "Energy to Setpoint",
+        "unit": "Wh",
+        "state_class": "measurement",
+        "precision": 0,
         "enabled": False,
     },
-    "available_energy_capacity": {
-        "attr": "available_energy_capacity",
-        "name": "Available Energy Capacity",
-        "device_class": "energy_storage",
+    # Energy to recover a fully depleted tank to the current setpoint.
+    "full_recovery_energy": {
+        "attr": "full_recovery_energy",
+        "name": "Full Recovery Energy",
         "unit": "Wh",
         "state_class": "measurement",
+        "precision": 0,
         "enabled": False,
     },
     # Percentage sensors

--- a/custom_components/nwp500/coordinator.py
+++ b/custom_components/nwp500/coordinator.py
@@ -543,7 +543,7 @@ class NWP500DataUpdateCoordinator(DataUpdateCoordinator[dict[str, Any]]):
         except ImportError as err:
             _LOGGER.error(
                 "nwp500-python library not installed. Please install: "
-                'uv pip install "nwp500-python==9.2.1" "awsiotsdk==1.31.0"'
+                'uv pip install "nwp500-python==9.3.0" "awsiotsdk==1.31.0"'
             )
             raise UpdateFailed(
                 f"nwp500-python library not available: {err}"

--- a/custom_components/nwp500/manifest.json
+++ b/custom_components/nwp500/manifest.json
@@ -18,7 +18,7 @@
     "custom_components.nwp500"
   ],
   "requirements": [
-    "nwp500-python==9.2.1",
+    "nwp500-python==9.3.0",
     "awsiotsdk==1.31.0"
   ],
   "single_config_entry": true,

--- a/custom_components/nwp500/strings.json
+++ b/custom_components/nwp500/strings.json
@@ -123,11 +123,14 @@
       "current_inst_power": {
         "name": "Current Power"
       },
-      "total_energy_capacity": {
-        "name": "Total Energy Capacity"
+      "usable_energy": {
+        "name": "Usable Energy"
       },
-      "available_energy_capacity": {
-        "name": "Available Energy Capacity"
+      "energy_to_setpoint": {
+        "name": "Energy to Setpoint"
+      },
+      "full_recovery_energy": {
+        "name": "Full Recovery Energy"
       },
       "dhw_charge_per": {
         "name": "DHW Charge"

--- a/custom_components/nwp500/translations/en.json
+++ b/custom_components/nwp500/translations/en.json
@@ -123,11 +123,14 @@
       "current_inst_power": {
         "name": "Current Power"
       },
-      "total_energy_capacity": {
-        "name": "Total Energy Capacity"
+      "usable_energy": {
+        "name": "Usable Energy"
       },
-      "available_energy_capacity": {
-        "name": "Available Energy Capacity"
+      "energy_to_setpoint": {
+        "name": "Energy to Setpoint"
+      },
+      "full_recovery_energy": {
+        "name": "Full Recovery Energy"
       },
       "dhw_charge_per": {
         "name": "DHW Charge"

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@
 
 # Usage: uv pip install -r requirements.txt
 # Core integration library
-nwp500-python==9.2.1
+nwp500-python==9.3.0
 
 # AWS IoT SDK for MQTT communication
 awsiotsdk==1.31.0

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -118,6 +118,12 @@ def mock_device_status() -> MagicMock:
     # Power and energy
     status.current_inst_power = 1200
     status.dhw_charge_per = 85
+    # nwp500-python 9.3.0 energy fields. Both are measured from the setpoint;
+    # usable_energy is their difference (full_recovery_energy -
+    # energy_to_setpoint), which is what the library computes.
+    status.full_recovery_energy = 9000.0
+    status.energy_to_setpoint = 2000.0
+    status.usable_energy = 7000.0
 
     # Error codes
     status.error_code = 0

--- a/tests/unit/test_init.py
+++ b/tests/unit/test_init.py
@@ -27,6 +27,21 @@ from custom_components.nwp500 import (
 from custom_components.nwp500.const import DOMAIN
 
 
+@pytest.fixture(autouse=True)
+def _no_registry_entries():
+    """Stub the entity registry lookup done during setup.
+
+    These tests drive ``async_setup_entry`` with a ``MagicMock`` hass, which
+    cannot back a real ``EntityRegistry``. Tests that care about the stale
+    entity cleanup patch this again with their own entries.
+    """
+    with patch(
+        "custom_components.nwp500.er.async_entries_for_config_entry",
+        return_value=[],
+    ):
+        yield
+
+
 class TestInit:
     """Tests for component initialization."""
 
@@ -110,6 +125,49 @@ async def test_async_setup_entry_stores_coordinator():
         assert DOMAIN in mock_hass.data
         assert mock_entry.entry_id in mock_hass.data[DOMAIN]
         assert mock_hass.data[DOMAIN][mock_entry.entry_id] == mock_coordinator
+
+
+def test_removes_energy_entities_dropped_in_9_3_0():
+    """Stale energy sensors are dropped from the registry, others are kept."""
+    from custom_components.nwp500 import _async_remove_stale_energy_entities
+
+    def entry(unique_id: str) -> MagicMock:
+        item = MagicMock()
+        item.unique_id = unique_id
+        item.entity_id = f"sensor.{unique_id}"
+        return item
+
+    stale = [
+        entry("AABBCCDDEEFF_total_energy_capacity"),
+        entry("AABBCCDDEEFF_available_energy_capacity"),
+    ]
+    kept = [
+        entry("AABBCCDDEEFF_usable_energy"),
+        entry("AABBCCDDEEFF_energy_to_setpoint"),
+        entry("AABBCCDDEEFF_full_recovery_energy"),
+        entry("AABBCCDDEEFF_current_inst_power"),
+    ]
+
+    mock_registry = MagicMock()
+    mock_entry = MagicMock()
+    mock_entry.entry_id = "test_entry"
+
+    with (
+        patch(
+            "custom_components.nwp500.er.async_get",
+            return_value=mock_registry,
+        ),
+        patch(
+            "custom_components.nwp500.er.async_entries_for_config_entry",
+            return_value=[*stale, *kept],
+        ),
+    ):
+        _async_remove_stale_energy_entities(MagicMock(), mock_entry)
+
+    removed = [
+        call.args[0] for call in mock_registry.async_remove.call_args_list
+    ]
+    assert removed == [e.entity_id for e in stale]
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_sensor.py
+++ b/tests/unit/test_sensor.py
@@ -78,6 +78,57 @@ class TestNWP500Sensor:
         # Value will be either the temperature or None if not available
         assert sensor.native_value is not None or sensor.native_value is None
 
+    def test_energy_sensors(
+        self,
+        mock_coordinator: MagicMock,
+        mock_device: MagicMock,
+        mock_device_status: MagicMock,
+    ):
+        """Test the nwp500-python 9.3.0 energy sensors.
+
+        The pre-9.3.0 ``total_energy_capacity`` / ``available_energy_capacity``
+        fields no longer exist on ``DeviceStatus``, so entities keyed on them
+        would silently read ``None`` forever.
+        """
+        from homeassistant.components.sensor import SensorDeviceClass
+
+        from custom_components.nwp500.sensor import create_sensor_descriptions
+
+        by_key = {d.key: d for d in create_sensor_descriptions()}
+
+        assert "total_energy_capacity" not in by_key
+        assert "available_energy_capacity" not in by_key
+
+        mac_address = mock_device.device_info.mac_address
+        mock_coordinator.data = {
+            mac_address: {
+                "device": mock_device,
+                "status": mock_device_status,
+            }
+        }
+
+        expected = {
+            "usable_energy": 7000.0,
+            "energy_to_setpoint": 2000.0,
+            "full_recovery_energy": 9000.0,
+        }
+        for key, value in expected.items():
+            desc = by_key[key]
+            sensor = NWP500Sensor(
+                mock_coordinator, mac_address, mock_device, desc
+            )
+            assert sensor.native_value == value
+            assert desc.native_unit_of_measurement == "Wh"
+
+        # Only usable_energy is a state of charge; the other two are measured
+        # from the setpoint and move when the setpoint moves.
+        assert (
+            by_key["usable_energy"].device_class
+            == SensorDeviceClass.ENERGY_STORAGE
+        )
+        assert by_key["energy_to_setpoint"].device_class is None
+        assert by_key["full_recovery_energy"].device_class is None
+
     def test_sensor_missing_value(
         self,
         mock_coordinator: MagicMock,

--- a/tox.ini
+++ b/tox.ini
@@ -13,7 +13,7 @@ deps =
     pytest-timeout>=2.1.0
 commands_pre =
     python -m pip install awsiotsdk==1.31.0
-    python -m pip install "nwp500-python==9.2.1" --no-deps
+    python -m pip install "nwp500-python==9.3.0" --no-deps
 
 [testenv:py314]
 description = Run tests on Python 3.14
@@ -24,7 +24,7 @@ description = Run mypy type checking
 deps =
     mypy>=1.0.0
     homeassistant>=2026.3.0
-    nwp500-python==9.2.1
+    nwp500-python==9.3.0
 commands_pre =
 
 [testenv:basedpyright]
@@ -32,7 +32,7 @@ description = Run basedpyright type checking
 deps =
     basedpyright>=1.0.0
     homeassistant>=2026.3.0
-    nwp500-python==9.2.1
+    nwp500-python==9.3.0
 commands_pre =
 
 [testenv:ruff]
@@ -64,7 +64,7 @@ deps =
     {[testenv]deps}
 commands_pre =
     python -m pip install awsiotsdk==1.31.0
-    python -m pip install "nwp500-python==9.2.1" --no-deps
+    python -m pip install "nwp500-python==9.3.0" --no-deps
 commands =
     pytest --cov=custom_components.nwp500 \
            --cov-report=html \


### PR DESCRIPTION
Adopts [nwp500-python 9.3.0](https://github.com/eman/nwp500-python/blob/main/CHANGELOG.rst). The repo was on 9.2.1, so only the 9.3.0 entry applies.

## Energy fields — breaking

9.3.0 corrected a unit-scale error in the tank energy fields and renamed them to match what they actually measure. Both old fields were **removed outright rather than aliased**, so the two sensors keyed on them would have silently read `None` forever.

| Removed entity | Replacement | Meaning |
| --- | --- | --- |
| Total Energy Capacity | Full Recovery Energy | Energy to recover a fully depleted tank to the current setpoint |
| Available Energy Capacity | Energy to Setpoint | Energy needed to bring the tank from its current temperature up to the setpoint |
| — | **Usable Energy** *(new, enabled by default)* | Energy drawable from the tank as useful hot water |

**Reported values are now 2.5x smaller.** The previous numbers were wrong, not the new ones. Recorded history and energy dashboard config built on the old entities needs rescaling by 0.4 or discarding.

One judgment call: `device_class: energy_storage` now applies to Usable Energy alone. The library's docstring is explicit that both device fields are measured *from the setpoint* — they move when the setpoint moves while the water in the tank does not — so only their difference is a state of charge. Full Recovery Energy and Energy to Setpoint keep unit Wh with no device class and stay disabled by default, as before.

## Stale entity cleanup

The two entities whose backing fields no longer exist are removed from the entity registry at setup. Without this they sit there permanently unavailable with no explanation, and their history is wrong regardless.

## Tristate status flags

The eight flags that became `bool | None` needed no code changes — `binary_sensor.is_on` already returns `bool | None`, `switch.py` already null-checks `anti_legionella_use`, and `water_heater`'s `any([...])` treats `None` as falsy. Unknown now renders as Unknown instead of a fabricated Off, which is a behavior change for automations assuming strict on/off. Documented in the changelog.

## Verification

- Field names and the `usable_energy` property checked against the installed 9.3.0, not just the changelog.
- 271 tests pass (added 2: one covering the three energy sensors and the absence of the old keys, one covering the registry cleanup).
- `ruff check` and `ruff format --check` clean.
- `mypy` reports 11 errors, byte-identical to the pre-existing set on `main` — verified by diffing against a stash.