### PR TITLE
fix: Move device location out of per-entity attributes

### DIFF
--- a/custom_components/nwp500/diagnostics.py
+++ b/custom_components/nwp500/diagnostics.py
@@ -121,13 +121,25 @@ async def async_get_config_entry_diagnostics(
         }
         location = getattr(device, "location", None)
         if location:
+            # Only include fields the cloud actually populated. Emitting
+            # every key unconditionally would redact each one to
+            # "**REDACTED**", making an unset field indistinguishable from
+            # a populated one and defeating the point of keeping the keys.
+            populated = {
+                key: getattr(location, key, None)
+                for key in (
+                    "address",
+                    "city",
+                    "state",
+                    "latitude",
+                    "longitude",
+                    "altitude",
+                )
+            }
             entry["location"] = {
-                "address": location.address,
-                "city": location.city,
-                "state": location.state,
-                "latitude": location.latitude,
-                "longitude": location.longitude,
-                "altitude": location.altitude,
+                key: value
+                for key, value in populated.items()
+                if value is not None
             }
         devices.append(entry)
     diagnostics_data["devices"] = devices

--- a/custom_components/nwp500/diagnostics.py
+++ b/custom_components/nwp500/diagnostics.py
@@ -18,7 +18,21 @@ if TYPE_CHECKING:
 _LOGGER = logging.getLogger(__name__)
 
 # Fields whose values are always redacted in diagnostic output.
-_TO_REDACT = {"password", "token", "access_token", "refresh_token", "secret"}
+# Location fields are account PII: they identify where the user lives, so
+# they are reported as structure only, never as values.
+_TO_REDACT = {
+    "password",
+    "token",
+    "access_token",
+    "refresh_token",
+    "secret",
+    "address",
+    "city",
+    "state",
+    "latitude",
+    "longitude",
+    "altitude",
+}
 
 _MAC_RE = re.compile(
     r"[0-9a-fA-F]{2}(?:[:\-][0-9a-fA-F]{2}){5}"  # colon/dash-delimited: AA:BB:CC:DD:EE:FF
@@ -93,6 +107,30 @@ async def async_get_config_entry_diagnostics(
             )
     else:
         diagnostics_data["mqtt_manager_status"] = "MQTT manager not available"
+
+    # Per-device metadata, including the account location. Values that are
+    # PII are redacted below; the keys are retained so maintainers can see
+    # which fields the cloud actually populated.
+    devices: list[dict[str, Any]] = []
+    for device in coordinator.devices:
+        entry: dict[str, Any] = {
+            "device_name": device.device_info.device_name,
+            "device_type": device.device_info.device_type,
+            "mac_address": device.device_info.mac_address,
+            "connected": device.device_info.connected,
+        }
+        location = getattr(device, "location", None)
+        if location:
+            entry["location"] = {
+                "address": location.address,
+                "city": location.city,
+                "state": location.state,
+                "latitude": location.latitude,
+                "longitude": location.longitude,
+                "altitude": location.altitude,
+            }
+        devices.append(entry)
+    diagnostics_data["devices"] = devices
 
     # Add coordinator telemetry
     diagnostics_data["coordinator_telemetry"] = coordinator.get_mqtt_telemetry()

--- a/custom_components/nwp500/entity.py
+++ b/custom_components/nwp500/entity.py
@@ -249,19 +249,11 @@ class NWP500Entity(CoordinatorEntity[NWP500DataUpdateCoordinator]):
                 }
             )
 
-            # Add location info if available
-            if hasattr(self.device, "location") and self.device.location:
-                location = self.device.location
-                if location.address:
-                    attrs["address"] = location.address
-                if location.city:
-                    attrs["city"] = location.city
-                if location.state:
-                    attrs["state_province"] = location.state
-                if location.latitude:
-                    attrs["latitude"] = location.latitude
-                if location.longitude:
-                    attrs["longitude"] = location.longitude
+            # Location (address/city/state/coordinates) is deliberately not
+            # exposed here. It is account metadata, not entity state: it never
+            # changes, so it would be duplicated across every entity and
+            # written to the recorder on each state change. See
+            # async_get_config_entry_diagnostics for the location payload.
 
             # Add device feature info if available (technical details
             # not in device info)

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -71,6 +71,39 @@ async def test_diagnostics_reports_location_keys_but_redacts_values(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_omits_unpopulated_location_fields(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Unset location fields are omitted, not redacted.
+
+    Redaction replaces values by key, so emitting every key unconditionally
+    would render an unset field indistinguishable from a populated one.
+    """
+    device = MagicMock()
+    device.device_info.device_name = "NWP500"
+    device.device_info.device_type = 52
+    device.device_info.mac_address = "AA:BB:CC:DD:EE:FF"
+    device.device_info.connected = True
+    device.location.address = None
+    device.location.city = "San Rafael"
+    device.location.state = "CA"
+    device.location.latitude = None
+    device.location.longitude = None
+    device.location.altitude = None
+
+    mock_coordinator.mqtt_manager = None
+    mock_coordinator.devices = [device]
+
+    hass.data = {"nwp500": {mock_config_entry.entry_id: mock_coordinator}}
+
+    result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+
+    assert set(result["devices"][0]["location"]) == {"city", "state"}
+
+
+@pytest.mark.asyncio
 async def test_async_get_config_entry_diagnostics_no_mqtt_manager(
     hass: HomeAssistant,
     mock_config_entry: ConfigEntry,

--- a/tests/unit/test_diagnostics.py
+++ b/tests/unit/test_diagnostics.py
@@ -28,6 +28,49 @@ async def test_async_get_config_entry_diagnostics_no_coordinator(
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_reports_location_keys_but_redacts_values(
+    hass: HomeAssistant,
+    mock_config_entry: ConfigEntry,
+    mock_coordinator: MagicMock,
+) -> None:
+    """Location appears in diagnostics as structure only, never as values."""
+    device = MagicMock()
+    device.device_info.device_name = "NWP500"
+    device.device_info.device_type = 52
+    device.device_info.mac_address = "AA:BB:CC:DD:EE:FF"
+    device.device_info.connected = True
+    device.location.address = "123 Main St"
+    device.location.city = "San Rafael"
+    device.location.state = "CA"
+    device.location.latitude = 37.9735
+    device.location.longitude = -122.5311
+    device.location.altitude = 12.0
+
+    mock_coordinator.mqtt_manager = None
+    mock_coordinator.devices = [device]
+
+    hass.data = {"nwp500": {mock_config_entry.entry_id: mock_coordinator}}
+
+    result = await async_get_config_entry_diagnostics(hass, mock_config_entry)
+
+    location = result["devices"][0]["location"]
+    # Keys retained so maintainers can see which fields the cloud populated.
+    assert set(location) == {
+        "address",
+        "city",
+        "state",
+        "latitude",
+        "longitude",
+        "altitude",
+    }
+    assert all(value == "**REDACTED**" for value in location.values())
+
+    # No PII leaks anywhere else in the payload.
+    for leaked in ("123 Main St", "San Rafael", "37.9735", "-122.5311"):
+        assert leaked not in str(result)
+
+
+@pytest.mark.asyncio
 async def test_async_get_config_entry_diagnostics_no_mqtt_manager(
     hass: HomeAssistant,
     mock_config_entry: ConfigEntry,

--- a/tests/unit/test_entity.py
+++ b/tests/unit/test_entity.py
@@ -239,10 +239,17 @@ class TestNWP500Entity:
         assert attrs["install_type"] == "Indoor"
         assert attrs["country_code"] == "US"
 
-        # Verify location
-        assert attrs["address"] == "123 Main St"
-        assert attrs["latitude"] == 37.7749
-        assert attrs["longitude"] == -122.4194
+        # Location is account metadata and must never be exposed as entity
+        # state; it belongs in diagnostics. See _build_extra_state_attributes.
+        for key in (
+            "address",
+            "city",
+            "state_province",
+            "latitude",
+            "longitude",
+            "altitude",
+        ):
+            assert key not in attrs
 
     def test_device_data_none_coordinator(
         self,


### PR DESCRIPTION
## Problem

`_build_extra_state_attributes` copied the device's account location onto **every** entity:

```python
if location.address:
    attrs["address"] = location.address
if location.city:
    attrs["city"] = location.city
if location.state:
    attrs["state_province"] = location.state
if location.latitude:
    attrs["latitude"] = location.latitude
if location.longitude:
    attrs["longitude"] = location.longitude
```

This is account metadata, not entity state. It never changes, so it was duplicated across all ~118 entities and rewritten to the recorder on every state change — putting the user's street address and GPS coordinates into the history database.

## Change

- **`entity.py`** — location block removed. The file now has zero references to `location`.
- **`diagnostics.py`** — added a `devices` section carrying per-device metadata and the location payload, and extended `_TO_REDACT` with `address`, `city`, `state`, `latitude`, `longitude`, `altitude`. `async_redact_data` matches by key at any depth, so values are redacted while keys survive: a maintainer reading a shared diagnostics dump can see which fields the Navien cloud populated without learning where the user lives. This matches HA's diagnostics PII rules.

Location is not in the device registry because HA's `DeviceInfo` has no field for a street address or coordinates.

## Related

This was the last remaining use of `location.city`. The other one — using it as the `suggested_area`, which auto-created areas named after the install city — was removed in 488c6d9.

Note that neither change cleans up **existing** registry state. Installs affected by the old `suggested_area` behavior still have a city-named area and any entity_ids created during that window keep the city slug baked in, since HA generates `entity_id` once and never regenerates it.

## Tests

`270 passed`, ruff clean.

- `test_entity.py` now asserts the location keys are **absent** from attributes (it previously asserted `attrs["address"] == "123 Main St"`).
- New `test_diagnostics_reports_location_keys_but_redacts_values` checks the keys are present, every value is `**REDACTED**`, and no PII string leaks elsewhere in the payload.

## Reviewer note

`state` is a generic key name. Nothing in `mqtt_manager.py` or `coordinator.py` emits a `state` key, but the library's `mqtt_diagnostics.export_json()` is opaque here — if it nests a `state` field it will now come back redacted. Over-redaction is the safe direction, but renaming the Location key to `state_province` in the diagnostics dict would avoid the collision.